### PR TITLE
Add URL sharing and JSON export features with toast notifications

### DIFF
--- a/day-vizualizer.html
+++ b/day-vizualizer.html
@@ -275,6 +275,27 @@
     .block.being-moved {
       opacity: 0.3;
     }
+
+    .toast {
+      position: fixed;
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: #323232;
+      color: white;
+      padding: 10px 24px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-family: 'Google Sans', Roboto, Arial, sans-serif;
+      z-index: 2000;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+      pointer-events: none;
+    }
+
+    .toast.visible {
+      opacity: 1;
+    }
   </style>
 </head>
 <body>
@@ -282,6 +303,9 @@
     <div id="toolbar">
       <button id="undo-btn" class="toolbar-btn" disabled title="Undo">&#x21A9; Undo</button>
       <button id="redo-btn" class="toolbar-btn" disabled title="Redo">Redo &#x21AA;</button>
+      <span style="flex:1"></span>
+      <button id="json-btn" class="toolbar-btn" title="Copy schedule as JSON">{ } JSON</button>
+      <button id="share-btn" class="toolbar-btn" title="Copy shareable link">&#x1F517; Share</button>
     </div>
     <div id="timeline-container">
       <div id="hour-labels"></div>
@@ -313,6 +337,77 @@
         future: []  // array of blocks snapshots for redo
       }
     };
+
+    // --- Serialization & URL state ---
+
+    function blocksToJSON(blocks) {
+      return blocks.map(b => ({ name: b.name, start: b.startTime, end: b.endTime }));
+    }
+
+    function blocksFromJSON(arr) {
+      return arr.map(item => ({
+        id: generateId(),
+        name: item.name || 'New Block',
+        startTime: item.start,
+        endTime: item.end
+      }));
+    }
+
+    function encodeStateToURL() {
+      if (state.blocks.length === 0) {
+        // Remove the query param if no blocks
+        const url = new URL(window.location);
+        url.searchParams.delete('s');
+        window.history.replaceState(null, '', url);
+        return;
+      }
+      const json = JSON.stringify(blocksToJSON(state.blocks));
+      const encoded = btoa(json);
+      const url = new URL(window.location);
+      url.searchParams.set('s', encoded);
+      window.history.replaceState(null, '', url);
+    }
+
+    function decodeStateFromURL() {
+      const params = new URLSearchParams(window.location.search);
+      const encoded = params.get('s');
+      if (!encoded) return null;
+      try {
+        const json = atob(encoded);
+        const arr = JSON.parse(json);
+        if (!Array.isArray(arr)) return null;
+        // Validate each entry
+        for (const item of arr) {
+          if (typeof item.start !== 'number' || typeof item.end !== 'number') return null;
+          if (item.start < DAY_START || item.end > DAY_END || item.end - item.start < MIN_DURATION) return null;
+        }
+        return blocksFromJSON(arr);
+      } catch (e) {
+        return null;
+      }
+    }
+
+    function getShareableURL() {
+      const json = JSON.stringify(blocksToJSON(state.blocks));
+      const encoded = btoa(json);
+      const url = new URL(window.location);
+      url.searchParams.set('s', encoded);
+      return url.toString();
+    }
+
+    function showToast(message) {
+      let toast = document.getElementById('toast');
+      if (!toast) {
+        toast = document.createElement('div');
+        toast.id = 'toast';
+        toast.className = 'toast';
+        document.body.appendChild(toast);
+      }
+      toast.textContent = message;
+      toast.classList.add('visible');
+      clearTimeout(toast._timeout);
+      toast._timeout = setTimeout(() => toast.classList.remove('visible'), 2000);
+    }
 
     // Helper functions
     function timeToY(minutes) {
@@ -935,6 +1030,8 @@
       });
 
       blocksLayer.replaceChildren(fragment);
+      // Sync URL with current state (skipping undo/redo history)
+      encodeStateToURL();
     }
 
     // Initialize timeline
@@ -961,15 +1058,51 @@
         gridLines.appendChild(line);
       }
 
-      // Timeline starts empty (no hardcoded test blocks)
+      // Load state from URL if present, otherwise start empty
+      const loadedBlocks = decodeStateFromURL();
+      if (loadedBlocks && loadedBlocks.length > 0) {
+        state.blocks = loadedBlocks;
+        state.blocks.sort((a, b) => a.startTime - b.startTime);
+      }
       renderBlocks();
 
-      // Scroll to ~5am area (300 minutes)
-      timelineContainer.scrollTop = timeToY(300);
+      // Scroll to ~5am area (300 minutes), or to first block if loaded from URL
+      if (state.blocks.length > 0) {
+        const firstBlockStart = state.blocks[0].startTime;
+        // Scroll so the first block is near the top with some padding
+        timelineContainer.scrollTop = Math.max(0, timeToY(firstBlockStart) - 40);
+      } else {
+        timelineContainer.scrollTop = timeToY(300);
+      }
 
       // Wire toolbar buttons
       document.getElementById('undo-btn').addEventListener('click', undo);
       document.getElementById('redo-btn').addEventListener('click', redo);
+
+      // Share button
+      document.getElementById('share-btn').addEventListener('click', () => {
+        if (state.blocks.length === 0) {
+          showToast('Nothing to share — add some blocks first');
+          return;
+        }
+        const url = getShareableURL();
+        navigator.clipboard.writeText(url).then(() => {
+          showToast('Shareable link copied to clipboard');
+        }, () => {
+          // Fallback: select a prompt
+          showToast('Could not copy — check clipboard permissions');
+        });
+      });
+
+      // JSON button
+      document.getElementById('json-btn').addEventListener('click', () => {
+        const json = JSON.stringify(blocksToJSON(state.blocks), null, 2);
+        navigator.clipboard.writeText(json).then(() => {
+          showToast('JSON copied to clipboard');
+        }, () => {
+          showToast('Could not copy — check clipboard permissions');
+        });
+      });
 
       // Create tooltip element
       const tooltip = document.createElement('div');

--- a/day-vizualizer.html
+++ b/day-vizualizer.html
@@ -1016,15 +1016,33 @@
         blockEl.style.height = `${height}px`;
 
         const duration = block.endTime - block.startTime;
-        blockEl.innerHTML = `
-          <div class="resize-handle resize-handle-top"></div>
-          <div class="block-content">
-            <span class="block-name">${block.name}</span>
-            <span class="block-duration">${formatDuration(duration)}</span>
-          </div>
-          <button class="block-delete" title="Delete block">&times;</button>
-          <div class="resize-handle resize-handle-bottom"></div>
-        `;
+
+        const handleTop = document.createElement('div');
+        handleTop.className = 'resize-handle resize-handle-top';
+
+        const content = document.createElement('div');
+        content.className = 'block-content';
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'block-name';
+        nameSpan.textContent = block.name;
+        const durationSpan = document.createElement('span');
+        durationSpan.className = 'block-duration';
+        durationSpan.textContent = formatDuration(duration);
+        content.appendChild(nameSpan);
+        content.appendChild(durationSpan);
+
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'block-delete';
+        deleteBtn.title = 'Delete block';
+        deleteBtn.textContent = '\u00d7';
+
+        const handleBottom = document.createElement('div');
+        handleBottom.className = 'resize-handle resize-handle-bottom';
+
+        blockEl.appendChild(handleTop);
+        blockEl.appendChild(content);
+        blockEl.appendChild(deleteBtn);
+        blockEl.appendChild(handleBottom);
 
         fragment.appendChild(blockEl);
       });
@@ -1096,6 +1114,10 @@
 
       // JSON button
       document.getElementById('json-btn').addEventListener('click', () => {
+        if (state.blocks.length === 0) {
+          showToast('Nothing to export — add some blocks first');
+          return;
+        }
         const json = JSON.stringify(blocksToJSON(state.blocks), null, 2);
         navigator.clipboard.writeText(json).then(() => {
           showToast('JSON copied to clipboard');


### PR DESCRIPTION
## Summary
This PR adds shareable URL functionality and JSON export capabilities to the day visualizer, allowing users to save and share their schedules. It also introduces a toast notification system for user feedback.

## Key Changes
- **URL State Persistence**: Schedule state is now encoded in the URL query parameter (`s`) using base64-encoded JSON, enabling shareable links and automatic restoration on page load
- **Share Button**: New toolbar button that copies a shareable URL to the clipboard with validation that blocks exist before sharing
- **JSON Export Button**: New toolbar button that exports the current schedule as formatted JSON to the clipboard
- **Toast Notifications**: Added a non-intrusive toast notification system that displays at the bottom center of the screen with 2-second auto-dismiss
- **Smart Scroll Behavior**: When loading a schedule from a URL, the page automatically scrolls to the first block instead of the default 5am position
- **State Validation**: URL decoding includes validation to ensure imported schedules have valid time ranges and block durations

## Implementation Details
- Serialization uses `blocksToJSON()` and `blocksFromJSON()` helper functions to convert between internal block format and shareable JSON
- URL encoding/decoding uses `btoa()`/`atob()` for base64 encoding with error handling for malformed URLs
- Toast notifications are created dynamically on first use and reused for subsequent messages
- The URL is automatically synced whenever blocks are rendered, keeping the shareable link up-to-date
- Clipboard operations include fallback error handling with appropriate user messaging

https://claude.ai/code/session_01GiMa8Pbj4EsGXYfwEXqAif

closes #4 