### PR TITLE
Use :focus-visible for cycle tracker inputs

### DIFF
--- a/cycle-tracker.html
+++ b/cycle-tracker.html
@@ -103,7 +103,7 @@
       transition: border-color 0.15s;
     }
 
-    .inputs input:focus {
+    .inputs input:focus-visible {
       outline: 2px solid #1a73e8;
       outline-offset: -1px;
       border-color: #1a73e8;


### PR DESCRIPTION
## Summary
- Changes `:focus` to `:focus-visible` on cycle tracker input styles, matching the html-tool skill guideline to only show focus rings on keyboard navigation, not mouse clicks

## Test plan
- [ ] Open `cycle-tracker.html` and click on date/number inputs — no focus ring should appear
- [ ] Tab into the inputs with keyboard — blue focus ring should appear

https://claude.ai/code/session_0116N5xRjNXLGLz7JwjmeUKq