### PR TITLE
[tool:rank-vote.html] Disable spellcheck on vote code input

### DIFF
--- a/rank-vote.html
+++ b/rank-vote.html
@@ -580,7 +580,8 @@ function renderTally() {
         <input type="text" name="name" placeholder="Name" required aria-label="Voter name">
         <input type="text" name="code" placeholder="Code" required class="code-input"
           minlength="${width}" maxlength="${width}" pattern="${pattern}"
-          autocapitalize="characters" aria-label="Vote code">
+          autocapitalize="characters" autocorrect="off" spellcheck="false"
+          autocomplete="off" aria-label="Vote code">
         <button type="submit" class="btn btn-primary">Add</button>
       </form>
       ${voteList || '<p class="empty-state">No votes entered yet</p>'}


### PR DESCRIPTION
## Summary
- The vote code input on the tally page is a Crockford Base32 string, not an English word, so browser spellcheck underlining was incorrect.
- Added `spellcheck="false"`, `autocorrect="off"`, and `autocomplete="off"` to the input to prevent browsers from treating the code as prose.

## Test plan
- [ ] Open `rank-vote.html`, create a ballot, go to the tally page, and type a partial/invalid code into the Code input
- [ ] Confirm no red spellcheck squiggle appears on mobile Safari/Chrome and desktop browsers
- [ ] Confirm existing Base32 normalization, pattern validation, and autocapitalization still work