### PR TITLE
lehmer-code: sync Integer panel after reorder on mobile

### DIFF
--- a/lehmer-code.html
+++ b/lehmer-code.html
@@ -366,13 +366,16 @@
       // Encode
       const { steps: encSteps, num } = permToIntSteps(state.perm);
 
-      // Integer inputs
+      // Integer inputs. Only skip a self-assignment that would reset the user's
+      // cursor / slider thumb — never skip updates that reflect state changed
+      // from a different control. (On iOS taps don't move focus off these
+      // inputs, so an activeElement guard here would block legitimate updates.)
       const intInput = document.getElementById('int-input');
       const intRange = document.getElementById('int-range');
       intInput.max = fact - 1;
       intRange.max = fact - 1;
-      if (document.activeElement !== intInput) intInput.value = num;
-      if (document.activeElement !== intRange) intRange.value = num;
+      if (intInput.value !== String(num)) intInput.value = num;
+      if (+intRange.value !== num) intRange.value = num;
       document.getElementById('int-readout').textContent = `rank ${num} of 0..${fact - 1}`;
 
       // Encode table


### PR DESCRIPTION
## Summary
Fixes a bug where the Integer panel (rank number, slider, readout) would stop updating after you reordered the permutation on mobile.

### Root cause
`render()` used `document.activeElement !== intInput/intRange` to decide whether to overwrite the inputs — the goal was to avoid resetting the user's cursor or slider thumb while they were actively driving that control. On desktop this worked because clicking a button moves focus to the button. On iOS (and several other mobile browsers) tapping a `<button>` does **not** move focus off a previously-focused input. So after using the slider or typing a rank, focus stays on that control, and tapping an arrow to reorder the permutation would trigger a re-render whose `activeElement` guard refused to update the Integer panel — leaving it stuck at the pre-reorder rank.

### Fix
Replace the `activeElement` guard with a value-equality check:

```js
if (intInput.value !== String(num)) intInput.value = num;
if (+intRange.value !== num) intRange.value = num;
```

This still skips the self-assignment that would reset a cursor / slider thumb while the user is driving that control (because the value already matches), but never blocks legitimate updates that originate from a different control.

### Verified with headless Chrome (rodney)
- Focus slider at rank 17, tap up/down arrow → perm changes to `D,C,B,A`, Integer panel correctly updates to rank 23 (previously frozen at 17).
- Type "12" into the rank input → value stays `12`, perm updates to the rank-12 permutation, no cursor churn.

## Test plan
- [ ] Open on a phone. Drag the slider to any non-zero rank, then tap an up/down arrow on the permutation. Integer input, slider thumb, and readout all move to the new rank.
- [ ] Type a rank directly in the number field. Cursor stays put while typing multi-digit numbers.
- [ ] Tap a row in the "All N! permutations" table → Integer panel jumps to that rank.

https://claude.ai/code/session_01561cxQLfZPJrKQJ6ZXeac5