### PR TITLE
Zero-pad vote codes to MAX_CHOICES width

### DIFF
--- a/rank-vote.html
+++ b/rank-vote.html
@@ -894,6 +894,10 @@ function codeWidth(n) {
   return w;
 }
 
+// Vote codes are zero-padded to the MAX_CHOICES width so short codes (e.g. "4")
+// display as "0004" — less likely to be mistaken for a rank number.
+const CODE_WIDTH = codeWidth(MAX_CHOICES);
+
 // --- Lehmer code ---
 // Vote codes encode a ranking permutation as an integer via the factorial number system.
 // permutation[rank] = choice index. Lehmer code converts this to a unique integer in [0, N!).
@@ -1078,7 +1082,7 @@ function renderCreate() {
 function renderVote() {
   const { title, choices } = state.election;
   const numChoices = choices.length;
-  const code = cb32Encode(permToInt(state.ranking), codeWidth(numChoices));
+  const code = cb32Encode(permToInt(state.ranking), CODE_WIDTH);
   let rows = '';
   for (let r = 0; r < numChoices; r++) {
     const choiceIdx = state.ranking[r];
@@ -1105,9 +1109,8 @@ function renderVote() {
 function renderTally() {
   const { title, choices } = state.election;
   const numChoices = choices.length;
-  const width = codeWidth(numChoices);
   const voteURL = getVoteURL();
-  const pattern = `[${CB32_CHAR_CLASS}]{${width}}`;
+  const pattern = `[${CB32_CHAR_CLASS}]{${CODE_WIDTH}}`;
   const { results, valid } = tallyResults(choices, state.votes);
 
   let voteList = '';
@@ -1159,7 +1162,7 @@ function renderTally() {
       <form class="vote-form" id="vote-form">
         <input type="text" name="name" placeholder="Name" required aria-label="Voter name">
         <input type="text" name="code" placeholder="Code" required class="code-input"
-          minlength="${width}" maxlength="${width}" pattern="${pattern}"
+          minlength="${CODE_WIDTH}" maxlength="${CODE_WIDTH}" pattern="${pattern}"
           autocapitalize="characters" autocorrect="off" spellcheck="false"
           autocomplete="off" aria-label="Vote code">
         <button type="submit" class="primary">Add</button>
@@ -1296,8 +1299,7 @@ app.addEventListener('input', (e) => {
       input.setSelectionRange(pos, pos);
     }
     const numChoices = state.election.choices.length;
-    const width = codeWidth(numChoices);
-    if (normalized.length === width) {
+    if (normalized.length === CODE_WIDTH) {
       input.setCustomValidity(isValidCode(normalized, numChoices) ? '' : 'Invalid vote code');
     } else {
       input.setCustomValidity('');


### PR DESCRIPTION
## Summary

- A bare vote code like `4` didn't immediately read as a *code* — it looked like a rank number. Now codes are always zero-padded to the `MAX_CHOICES` width (4 Crockford Base32 digits), so that same code displays as `0004`.
- Introduces `CODE_WIDTH = codeWidth(MAX_CHOICES)` and uses it everywhere a code is displayed or entered: the vote-page code display, the tally page's code-input `minlength`/`maxlength`/`pattern`, and the inline validity check.
- Decoding is unchanged. Leading zeros don't affect the factorial-base integer, so existing ballot URLs still decode and round-trip correctly.

Supersedes #51.

## Test plan

- [ ] 2-choice ballot: default code renders as `0000`; swapping ranking renders `0001`
- [ ] Tally input has `maxlength=4` and correct Crockford Base32 pattern
- [ ] Submitting valid codes tallies correctly; out-of-range codes are rejected
- [ ] Vote-list chips display padded codes
- [ ] 8-choice ballot still uses width 4 (unchanged — already the ceiling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)