### PR TITLE
Match Dutch Blitz presets to actual card colors

### DIFF
--- a/dutch-blitz.html
+++ b/dutch-blitz.html
@@ -57,16 +57,13 @@
       --warning-bg: #fef7e0;
       --warning: #996700;
 
-      /* Dutch Blitz deck colors. Original (green box) deck colors first, then
-         blue expansion alternates for the same four symbols. */
+      /* Dutch Blitz deck colors. Both the Classic Green box and the Blue
+         Expansion print on the same four ink colors; each pack assigns those
+         colors to a different rotation of the four symbols. */
       --db-green:  oklch(0.62 0.16 145);
       --db-red:    oklch(0.55 0.20 27);
       --db-blue:   oklch(0.55 0.17 250);
       --db-yellow: oklch(0.82 0.16 92);
-      --db-orange: oklch(0.70 0.17 55);
-      --db-purple: oklch(0.50 0.20 305);
-      --db-pink:   oklch(0.72 0.17 5);
-      --db-teal:   oklch(0.65 0.13 195);
     }
 
     @supports (color: oklch(0 0 0)) {
@@ -598,14 +595,14 @@
     };
 
     const PRESETS = [
+      { id: 'blue-plow',       label: 'Blue Plow',       symbol: 'plow',     color: 'var(--db-blue)',   pack: 'classic' },
       { id: 'green-pump',      label: 'Green Pump',      symbol: 'pump',     color: 'var(--db-green)',  pack: 'classic' },
       { id: 'red-carriage',    label: 'Red Carriage',    symbol: 'carriage', color: 'var(--db-red)',    pack: 'classic' },
-      { id: 'blue-plow',       label: 'Blue Plow',       symbol: 'plow',     color: 'var(--db-blue)',   pack: 'classic' },
       { id: 'yellow-pail',     label: 'Yellow Pail',     symbol: 'pail',     color: 'var(--db-yellow)', pack: 'classic' },
-      { id: 'orange-pump',     label: 'Orange Pump',     symbol: 'pump',     color: 'var(--db-orange)', pack: 'blue' },
-      { id: 'purple-carriage', label: 'Purple Carriage', symbol: 'carriage', color: 'var(--db-purple)', pack: 'blue' },
-      { id: 'pink-plow',       label: 'Pink Plow',       symbol: 'plow',     color: 'var(--db-pink)',   pack: 'blue' },
-      { id: 'teal-pail',       label: 'Teal Pail',       symbol: 'pail',     color: 'var(--db-teal)',   pack: 'blue' },
+      { id: 'blue-pump',       label: 'Blue Pump',       symbol: 'pump',     color: 'var(--db-blue)',   pack: 'blue' },
+      { id: 'red-plow',        label: 'Red Plow',        symbol: 'plow',     color: 'var(--db-red)',    pack: 'blue' },
+      { id: 'yellow-carriage', label: 'Yellow Carriage', symbol: 'carriage', color: 'var(--db-yellow)', pack: 'blue' },
+      { id: 'green-pail',      label: 'Green Pail',      symbol: 'pail',     color: 'var(--db-green)',  pack: 'blue' },
     ];
     const PRESET_BY_ID = Object.fromEntries(PRESETS.map(p => [p.id, p]));
 


### PR DESCRIPTION
## Summary

Both Dutch Blitz decks (Classic Green box and Blue Expansion) print on the same four ink colors — red, blue, green, yellow — and rotate which symbol gets which color. The previous presets invented four extra colors (orange/purple/pink/teal) that don't exist on the cards.

Real mapping (from the photo of both decks side-by-side):

| Symbol | Classic Green | Blue Expansion |
|---|---|---|
| Plow | Blue | Red |
| Pump | Green | Blue |
| Carriage | Red | Yellow |
| Pail | Yellow | Green |

### Reference photo
![Photo of all eight Dutch Blitz card designs across the Classic Green box and Blue Expansion](https://github.com/quidge/tools/releases/download/asset-dump/019dcbe7-2651+3848ae3a-3d19-4721-b4ba-fb11c237df75.jpg)

### Before: setup picker invented four expansion colors
![Before screenshot showing the old preset row with orange pump, purple carriage, pink plow, and teal pail in addition to the four classic colors](https://github.com/quidge/tools/releases/download/asset-dump/before-setup+2aac629f-a8fe-4292-aaf8-30db1bcc2d7c.png)

### After: setup picker shows the real eight presets
![Setup view with four players, showing the eight preset tiles in their true colors — blue plow, green pump, red carriage, yellow pail, blue pump, red plow, yellow carriage, green pail](https://github.com/quidge/tools/releases/download/asset-dump/setup-4players+08789979-9a2d-44af-8352-e89b5d5030b0.png)

### After: scoreboard avatars use the new presets
![Scoreboard with four players using green pump, red carriage, blue plow, and yellow pail avatars](https://github.com/quidge/tools/releases/download/asset-dump/scoreboard+3eb4a9a6-0533-4f7c-9b29-8ae5ce9b331a.png)

## Test plan

- [x] Setup picker renders the four Classic and four Blue Expansion presets in the correct colors
- [x] "Taken" presets dim correctly when another player has selected them
- [x] Round dialog and scoreboard avatars use the new presets
- [x] Adding rounds and editing scores still works end-to-end
