### PR TITLE
Fix Dutch Blitz player setup layout on mobile

### DIFF
--- a/dutch-blitz.html
+++ b/dutch-blitz.html
@@ -244,10 +244,18 @@
       border-radius: var(--radius-md);
     }
 
+    .player-row-main {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+      min-width: 0;
+    }
+
     .player-row .name-row {
       display: flex;
       gap: var(--space-2);
       align-items: stretch;
+      min-width: 0;
     }
 
     .player-row .name-input {
@@ -489,6 +497,19 @@
       #app { padding: var(--page-padding-mobile); }
       h1 { font-size: var(--text-xl); }
       .player-header .player-total { font-size: var(--text-2xl); }
+
+      .player-row {
+        grid-template-columns: auto 1fr;
+        grid-template-areas:
+          "avatar name"
+          "presets presets";
+        column-gap: var(--space-3);
+        row-gap: var(--space-2);
+      }
+      .player-row > .player-avatar { grid-area: avatar; }
+      .player-row-main { display: contents; }
+      .player-row-main > .name-row { grid-area: name; }
+      .player-row-main > .preset-grid { grid-area: presets; margin-top: 0; }
     }
   </style>
 </head>
@@ -718,10 +739,7 @@
       wrap.appendChild(renderAvatar(preset, 'lg'));
 
       const middle = document.createElement('div');
-      middle.style.display = 'flex';
-      middle.style.flexDirection = 'column';
-      middle.style.gap = 'var(--space-2)';
-      middle.style.minWidth = '0';
+      middle.className = 'player-row-main';
 
       const nameInput = document.createElement('input');
       nameInput.type = 'text';


### PR DESCRIPTION
## Summary

The avatar in the Dutch Blitz player setup card previously occupied a tall left-hand column at every viewport width, squeezing the name input into a narrow strip on phones. On mobile (≤600px), the avatar now sits inline with the name input on the first row, and the 8-tile preset grid wraps to a full-width row below.

The change is CSS-only behind a media query plus replacing inline styles on the middle wrapper with a `.player-row-main` class so it can be overridden. Desktop layout (avatar in its own column, name + preset grid stacked beside it) is unchanged.

## Before / After

### Mobile

Before — name input crammed next to the X button, avatar takes its own column:

![Dutch Blitz player setup on mobile before the fix, showing avatar in a tall left column and a narrow name input](https://github.com/quidge/tools/releases/download/asset-dump/before-mobile-full+cc88b39b-0392-4524-b441-94ef84992a88.png)

After — avatar joins the name row, preset grid spans the full card width:

![Dutch Blitz player setup on mobile after the fix, with avatar inline next to the name input and the preset grid filling the row below](https://github.com/quidge/tools/releases/download/asset-dump/after-mobile-full+0c21c1c3-ef3c-484b-b7a9-962ec2edf2ac.png)

### Desktop (unchanged)

Before:

![Dutch Blitz player setup on desktop before the fix](https://github.com/quidge/tools/releases/download/asset-dump/before-desktop+a225985d-9e29-4df2-9ef3-24b3cdb3185b.png)

After:

![Dutch Blitz player setup on desktop after the fix, identical to before](https://github.com/quidge/tools/releases/download/asset-dump/after-desktop+354b2fa9-f3b3-4062-bf06-c96e11bb5a15.png)

## Test plan

- [x] Mobile viewport (~390px): avatar + name + remove button on row 1; 8-tile preset grid spans the full card width on row 2
- [x] Desktop viewport (~1280px): layout matches `main` — avatar in its own left column, name row + preset grid stacked to the right
- [x] Existing add/remove player and preset selection still work (no DOM structure changes apart from removing inline styles in favor of a class)

https://claude.ai/code/session_01SaxTp5MX8hHWHgxRpiGpQ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaxTp5MX8hHWHgxRpiGpQ2)_