### PR TITLE
Allow entering negative round scores in Dutch Blitz on mobile

### DIFF
--- a/dutch-blitz.html
+++ b/dutch-blitz.html
@@ -472,6 +472,23 @@
       align-items: flex-end;
       gap: var(--space-1);
     }
+    .round-input-row .score-input-group {
+      display: flex;
+      gap: var(--space-2);
+      align-items: stretch;
+    }
+    .round-input-row .sign-toggle {
+      min-width: 44px;
+      padding: 0;
+      font-size: var(--text-lg);
+      font-weight: 600;
+      line-height: 1;
+    }
+    .round-input-row .sign-toggle[aria-pressed="true"] {
+      background: var(--accent-light);
+      border-color: var(--accent);
+      color: var(--accent);
+    }
     .round-input-row .score-input {
       width: 96px;
       text-align: center;
@@ -1072,11 +1089,37 @@
             errorEl.textContent = '';
             invalidScores.delete(pl.id);
             roundDraft[pl.id] = n;
+            signToggle.setAttribute('aria-pressed', n < 0 ? 'true' : 'false');
           }
           roundSaveBtn.disabled = invalidScores.size > 0;
         });
 
-        scoreCell.appendChild(scoreInput);
+        const signToggle = document.createElement('button');
+        signToggle.type = 'button';
+        signToggle.className = 'sign-toggle';
+        signToggle.textContent = '±';
+        signToggle.title = 'Toggle positive / negative';
+        signToggle.setAttribute('aria-label', `Toggle sign for ${pl.name} round score`);
+        signToggle.setAttribute('aria-pressed', roundDraft[pl.id] < 0 ? 'true' : 'false');
+        signToggle.addEventListener('click', () => {
+          const raw = scoreInput.value.trim();
+          const n = raw === '' ? 0 : Number(raw);
+          if (!Number.isFinite(n) || n === 0) {
+            scoreInput.focus();
+            return;
+          }
+          scoreInput.value = String(-n);
+          scoreInput.focus();
+          scoreInput.select();
+          scoreInput.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+
+        const inputGroup = document.createElement('div');
+        inputGroup.className = 'score-input-group';
+        inputGroup.appendChild(signToggle);
+        inputGroup.appendChild(scoreInput);
+
+        scoreCell.appendChild(inputGroup);
         scoreCell.appendChild(errorEl);
         row.appendChild(scoreCell);
 


### PR DESCRIPTION
## Bug

> Hey you need to add in that program the ability to do minus because it
> only counts the Plus points but when you go negative there's no way to
> put it in the number board

The Dutch Blitz scorekeeper accepts net round scores from -99 to 99 — the
validation logic already permits negatives (`MIN_INPUT_SCORE = -99` in
`dutch-blitz.html`). However, each score input is rendered with
`type="number"` and `inputMode="numeric"`, which on most mobile keypads
exposes only digits 0–9 with no minus key. Net scores genuinely go
negative (−2 per card left in the Blitz pile), so this blocked mobile
players from logging losing rounds.

### Reproduction (mobile viewport, before the fix)

The round entry dialog has no way to enter a negative number — the
keypad is digits-only and there's no UI affordance for sign.

![Round dialog before fix — no way to enter a minus on mobile](https://github.com/quidge/tools/releases/download/asset-dump/before-dialog+3db015a4-b5a4-40c2-92e3-24fb2690379d.png)

## Fix

Add a small `±` toggle button to the left of each score input inside the
round-entry dialog. Tapping it flips the sign of the current value
(no-op on 0/empty so the focus just returns to the input). The button
adopts an `aria-pressed="true"` state while the value is negative for a
subtle visual cue.

Design notes:
- Kept the existing `type="number"` + `inputMode="numeric"` so the fast
  numeric keypad still appears on mobile.
- The button reuses the existing 44px touch target, accent palette, and
  border / spacing tokens already defined in the file. No new design
  primitives.
- Validation, save/edit logic, totals, and round deltas are unchanged —
  the button only mutates the input value and dispatches an `input`
  event, so the existing handler does all the work.

### After the fix

Each player row now has a `±` button next to the score input:

![Round dialog after fix — ± button next to each input](https://github.com/quidge/tools/releases/download/asset-dump/after-dialog+8cab8899-9ee8-41d8-9444-55b1c5d8ffb8.png)

Typing `8` and tapping `±` gives `-8`. The toggle is highlighted while
the value is negative:

![Round dialog with -8 entered for Anna and 12 for Ben](https://github.com/quidge/tools/releases/download/asset-dump/after-dialog-negative+86cf9d9c-5cce-4215-ba67-15cc009e8acb.png)

The scoreboard then carries negatives through running totals correctly —
Anna at -8 then +5 = -3, with a red delta indicator:

![Scoreboard showing Anna at -3 running total after a negative round](https://github.com/quidge/tools/releases/download/asset-dump/after-scoreboard+7327c679-cad0-4037-96a9-872a03a6fdf6.png)

Desktop view is preserved — the native number-input spinner still works,
and the `±` button is just another inline affordance:

![Dialog on desktop with the new ± button alongside the native number input](https://github.com/quidge/tools/releases/download/asset-dump/after-dialog-desktop+5a93ab04-a40c-43b4-97e2-0c7b0cd9f9aa.png)

## Test plan

- [x] Mobile (iPhone 13 viewport, Playwright): enter positive, tap `±`, value becomes negative; save round; totals reflect the negative.
- [x] Mobile: enter two rounds (one with a negative for each player) and verify running totals (Anna −8 then +5 → −3; Ben +12 then −3 → 9).
- [x] Desktop: `±` button renders inline next to the native number-input spinner; toggle still flips sign.
- [x] Validation path unchanged: out-of-range and non-integer values still surface the existing error.

https://claude.ai/code/session_01X6iGcr6uF6WwLA6DgKjUTR

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6iGcr6uF6WwLA6DgKjUTR)_