### PR TITLE
Add sound-board tool with embedded fuaaa sound effect

### DIFF
--- a/sound-board.html
+++ b/sound-board.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Sound Board</title>
+  <style>
+    :root {
+      --page-max-width: 800px;
+      --page-padding: 24px;
+      --page-padding-mobile: 16px;
+
+      --space-1: 0.25rem;
+      --space-2: 0.5rem;
+      --space-3: 0.75rem;
+      --space-4: 1rem;
+      --space-5: 1.25rem;
+      --space-6: 1.5rem;
+      --space-8: 2rem;
+
+      --text-sm: 0.875rem;
+      --text-base: 1rem;
+      --text-lg: 1.125rem;
+      --text-xl: 1.25rem;
+      --text-2xl: 1.5rem;
+
+      --line-heading: 1.25;
+      --line-ui: 1.4;
+      --line-copy: 1.5;
+      --control-min-height: 44px;
+
+      --radius-sm: 6px;
+      --radius-md: 10px;
+      --radius-lg: 12px;
+      --transition-fast: 0.15s;
+
+      /* --- Hex fallbacks (pre-oklch browsers) --- */
+      --bg: #f8f9fa;
+      --surface: #ffffff;
+      --hover: #f1f3f4;
+      --border: #dadce0;
+      --text-muted: #9aa0a6;
+      --text-secondary: #5f6368;
+      --text-primary: #202124;
+      --toast-bg: #323232;
+
+      --accent-light: #e8f0fe;
+      --accent: #2d5ed4;
+      --accent-hover: #1765cc;
+
+      --error-bg: #fce8e6;
+      --error: #bb061e;
+      --success-bg: #e6f4ea;
+      --success: #00763a;
+      --warning-bg: #fef7e0;
+      --warning: #996700;
+    }
+
+    @supports (color: oklch(0 0 0)) {
+      :root {
+        --bg: oklch(0.975 0.003 264);
+        --surface: oklch(1 0 0);
+        --hover: oklch(0.955 0.003 264);
+        --border: oklch(0.88 0.005 264);
+        --text-muted: oklch(0.69 0.01 264);
+        --text-secondary: oklch(0.50 0.01 264);
+        --text-primary: oklch(0.23 0.005 264);
+        --toast-bg: oklch(0.27 0 0);
+
+        --accent-light: oklch(0.93 0.04 264);
+        --accent: oklch(0.52 0.19 264);
+        --accent-hover: oklch(0.495 0.18 264);
+
+        --error-bg: oklch(0.94 0.03 25);
+        --error: oklch(0.50 0.2 25);
+        --success-bg: oklch(0.94 0.04 155);
+        --success: oklch(0.49 0.14 155);
+        --warning-bg: oklch(0.94 0.05 85);
+        --warning: oklch(0.55 0.15 85);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html, body {
+      height: 100%;
+    }
+
+    body {
+      font-family: system-ui, sans-serif;
+      font-size: var(--text-base);
+      background: var(--bg);
+      color: var(--text-primary);
+      line-height: var(--line-copy);
+      /* Lock to the viewport: the board fills the screen, no scrolling. */
+      overflow: hidden;
+      overscroll-behavior: none;
+    }
+
+    button {
+      font: inherit;
+    }
+
+    #app {
+      max-width: var(--page-max-width);
+      margin: 0 auto;
+      /* Fill the visible viewport (dvh tracks mobile browser chrome). */
+      height: 100dvh;
+      padding: calc(var(--page-padding) + env(safe-area-inset-top, 0px))
+               calc(var(--page-padding) + env(safe-area-inset-right, 0px))
+               calc(var(--page-padding) + env(safe-area-inset-bottom, 0px))
+               calc(var(--page-padding) + env(safe-area-inset-left, 0px));
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      flex: 0 0 auto;
+      margin-bottom: var(--space-4);
+    }
+
+    h1 {
+      font-size: var(--text-2xl);
+      line-height: var(--line-heading);
+      margin-bottom: var(--space-1);
+    }
+
+    p.description {
+      color: var(--text-secondary);
+      font-size: var(--text-sm);
+      max-width: 60ch;
+    }
+
+    /* --- Board: 2x2 grid that grows to fill remaining height --- */
+    .board {
+      flex: 1 1 auto;
+      min-height: 0;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr 1fr;
+      gap: var(--space-3);
+    }
+
+    .pad {
+      /* Big, mashable touch target. */
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: var(--space-2);
+
+      border: 1px solid var(--accent);
+      border-radius: var(--radius-lg);
+      background: var(--accent-light);
+      color: var(--accent-hover);
+      cursor: pointer;
+
+      font-weight: 800;
+      font-size: clamp(1.5rem, 7vw, 2.75rem);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      line-height: 1;
+
+      -webkit-tap-highlight-color: transparent;
+      touch-action: manipulation;
+      user-select: none;
+      transition: transform var(--transition-fast) ease,
+                  background var(--transition-fast) ease,
+                  box-shadow var(--transition-fast) ease;
+    }
+
+    .pad .pad-label {
+      pointer-events: none;
+    }
+
+    .pad .pad-index {
+      font-size: var(--text-sm);
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      color: var(--accent);
+      opacity: 0.7;
+      pointer-events: none;
+    }
+
+    .pad:hover:not(:active) {
+      background: oklch(0.91 0.05 264);
+    }
+
+    .pad:focus-visible {
+      outline: 3px solid var(--accent);
+      outline-offset: 3px;
+    }
+
+    /* Pressed / actively-playing pad gets a filled, punched-in look. */
+    .pad:active,
+    .pad.playing {
+      background: var(--accent);
+      color: var(--surface);
+      transform: scale(0.97);
+      box-shadow: inset 0 3px 10px rgba(0, 0, 0, 0.25);
+    }
+
+    .pad.playing .pad-index {
+      color: var(--surface);
+      opacity: 0.85;
+    }
+
+    /* Quick flash on every (re)trigger, even when already playing. */
+    @keyframes pad-pulse {
+      0%   { transform: scale(0.93); }
+      100% { transform: scale(0.97); }
+    }
+    .pad.trigger {
+      animation: pad-pulse 0.12s ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .pad { transition: background var(--transition-fast) ease; }
+      .pad.trigger { animation: none; }
+      .pad:active, .pad.playing { transform: none; }
+    }
+
+    /* --- Responsive --- */
+    @media (max-width: 600px) {
+      #app {
+        padding: calc(var(--page-padding-mobile) + env(safe-area-inset-top, 0px))
+                 calc(var(--page-padding-mobile) + env(safe-area-inset-right, 0px))
+                 calc(var(--page-padding-mobile) + env(safe-area-inset-bottom, 0px))
+                 calc(var(--page-padding-mobile) + env(safe-area-inset-left, 0px));
+      }
+      header { margin-bottom: var(--space-3); }
+      h1 { font-size: var(--text-xl); }
+    }
+
+    /* Short / landscape screens: keep all four pads visible without scrolling. */
+    @media (max-height: 480px) {
+      header { margin-bottom: var(--space-2); }
+      h1 { font-size: var(--text-lg); margin-bottom: 0; }
+      p.description { display: none; }
+      .board { gap: var(--space-2); }
+    }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <header>
+      <h1>Sound Board</h1>
+      <p class="description">Tap a pad to fire the <strong>FUAAA</strong> sound. Tap again to cut it off and replay instantly.</p>
+    </header>
+
+    <main class="board" id="board" aria-label="Sound pads">
+      <button type="button" class="pad" data-pad="0">
+        <span class="pad-index">01</span>
+        <span class="pad-label">Fuaaa</span>
+      </button>
+      <button type="button" class="pad" data-pad="1">
+        <span class="pad-index">02</span>
+        <span class="pad-label">Fuaaa</span>
+      </button>
+      <button type="button" class="pad" data-pad="2">
+        <span class="pad-index">03</span>
+        <span class="pad-label">Fuaaa</span>
+      </button>
+      <button type="button" class="pad" data-pad="3">
+        <span class="pad-index">04</span>
+        <span class="pad-label">Fuaaa</span>
+      </button>
+    </main>
+  </div>
+
+  <script>
+    // --- Embedded "fuaaa" / FAAAH TikTok sound effect (MP3, ~2s) ---
+    // Base64 data URI so the tool stays a single self-contained file and the
+    // audio is versioned directly in git. Decoded once via Web Audio API; each
+    // pad keeps its own "voice" so a re-tap cleanly cuts off and restarts.
+    const AUDIO_SRC = "data:audio/mpeg;base64,SUQzBAAAAAABAFRYWFgAAAASAAADbWFqb3JfYnJhbmQAZGFzaABUWFhYAAAAEQAAA21pbm9yX3ZlcnNpb24AMABUWFhYAAAAHAAAA2NvbXBhdGlibGVfYnJhbmRzAGlzbzZtcDQxAFRTU0UAAAAPAAADTGF2ZjYwLjE2LjEwMAAAAAAAAAAAAAAA//uwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAA8AAABLAAC6HgAGCg0QEBQXGhoeISUlKCsvLzI1OTk8P0NDRkpNTVBUV1daXmFhZWhra29ydXV5fH9/g4aKio2QlJSXmp6eoaWoqKuvsrK1uby8v8PGxsrN0NDU19ra3uHl5ejr7+/y9fn5/P8AAAAATGF2YzYwLjMxAAAAAAAAAAAAAAAAJANAAAAAAAAAuh4e1PLZAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/+7BkAACEVmKtQShmSENslfIAIm5VLYi8p53+QiSymKQErWgFAGXX85EAYLiudPycLnSmMTUxG8gJLQMagTNwvd+oC59icD3cgUW/9/3KMFMhXe6sfT7kGIoLBDOBorlsY56Tc2KDRwCYbDyv////GCQck+NITIg4AYXy3ROjWXbX+whiXHiwzeiO7cwlNxLeOER+cLSfGvfmZmZnsWIZbzpmZmZnENG8iEtCZs5cBrLjmOpjIH0bx//6gR7/o2rBxYQRU8/53OjOQGLJIU6iwhRyIQQc6MHHA0////1Onsp0ISjHb//6E1zu7HRj6HCCB4CAATwmCLMdheshpncV8FDBJyXxoScP1GNqbWIDxyKsMNxmPcG/SA+Lghirw8jq1aak0IWXimVWx///9SKCrYWxIrGui3KJk53y89RDCo1Xqq7EljwA3xQJAloUFoO5xoUALDALiP//SEnXfsp24p4r1jFvLm+Q9SIe72kwbZ5zvGxLHI1wzrUbtrOxL7hL7Y3x6nW6/////yUZr/////+g+CxKmI0p0f+4k3iZbli4CBi6IgMGGGgCF2MBQGDSFUXBAA8X///wbjwSADAJzw8iCEUnFd//FRXnTcfzngkASDOP/QYQIyJo8JmpKOpE4tKCDKrNTYP44LxFADEHGZEoh4r///////mygfHPDMN7NB4APL0jgJAODjw8XP////6g/p+H8Bu8gBGEBS8Gn5IQkmIEABkGKoOBUA5obbVFZYjbI6iNgDE820ih5G20GGR3UJOJyiAkiSQxcV5NAY5GTyjqmT+aoxlrs5RAYbfZOfabG0eswJFS1ShmeZnmCP/7smQmgES+Z7XJJ0+Qlqy2ZzFpuBQVnvBtpRVJ4rJdMCwdoIJBaOAvCYVnv//rphHOzhAURyI/jiahXviIz7kAoNnxeaipdptqCqjcUBhIjb///uH6AfSQIGG9nvnRAqLisoseJFM3VIZAgFAoYQACAAIBM0SCAIjnTMzpw4W1wkKmA4AxRIJaCBgSx3eQFmcrfRFsV///JLODYqSUTQ8RSgiExn/IIYD+/IiI3HBsDwQhoe/99jwAmL0jQfCgcNkoRDuGkJoLrmCUFCCVzMkz7J29////////8PbZx5MmTp3OJQVtgebOVpoPggSZ///////MgVnJzkc0Zp5AoxPJ09BMcgCEpGadWygUKSRU3dYuAkQriDEU37mlbC4BgAAWYLSKWP+udg7tsPkTKFAEHFr1nAVIBDEILutefbUsRuqFtpKR+4UYgxSmKMLzhd3SNtSFKKk9mTZRiftIwRo818y7aFli/X////8unjKFKLYUMHIaKL0NEc8G555AoRohBn5bBwSfF3//jlxQUEg6ceLTYTl25AvBA4Oz3lkHpQwQFF6XEDAAAIOQWHf9Aa0y5aAMtoW0LuFtExAQIMA0tt4YQSF4GgO3R/WxnF//HDwHjYSxxirjhi/sn3SqN/UoD8SzjxeOCx0PLmFRuOA8B4LCAjg/G56uOEDG///9T84RAeCQQcblz3HxLRp43b//1MVZ6EDz7ow+e2YONQA2AbbXQZ7EyZ8geZTDEYLgSOAgY4MrGIhhumhj9Zq4ATsN6rNUONK1C0QaogooAAAEEVAsXCFwlAMiXEYoBSwIGBREzrcADzJ9Vsq5jK9y2wJI4f/7smQqAIa1Zzyrunlwasw30BcHZhddRxWtYefCBShi9Aw9nbLtL6mwhZvl3VapgKtj7AYg9asP5QF4W90mjKhYXnTyrce6KVD4ehvf/Hu/Y1etvNXvCn67c7azff/xr//7/aomvz/WV5KLb9eWVuZ/6SOlZp+m1QZbmwOKPyejLr/QyEIWVw/pfdKf41elJHB+/+Lx82gxu8jx4/Y8sc8TOoFP7t8/jX/dgZMiEoRw6lWyprDNRIamYoJCQyiNx1NMXx8J1PQxl/8VoKiQ3PUeRv+/U8b0HC1v0FYuMFYoEww9R5yCBQshYH5AqT1KEa////5wmGhYfMHxUXMUFhVCBASP//qYQ1JnkKug+NDKgwE24XHNvrVGBNoQmRp2nIZQMRCx0CmYv58TsIUQkWstTU4qUBeWGyQhEBSkggXoJDofEhC8Trs5NhFnVGkNo/hhGKWwF0Rq7Vw7BwD7Adwg8IwCCH0c6vDgUAtioU6PPQhg3zwnayT3kcGdjRI3zjT8JcTIs4zcOis9PmycG+MdqSKPL4dDZT/H///9/////f334Bb3yg2dhCHqfZ4l8XRBCGhTl/RmFw8eIY6XDhv6hwjobVEdE58T//qE0skjSACswia8A2kCrC6E10J6GZbxM8VKr9IVkCsLS8SIt6Xnw/8SfGv//8RFQ4lvxDXhbB4ZvfWd01qsff8CjwtiUP9zvH/p8a7Bu6nOdXn+o42TfXDCXNRmWu48JoE/JvTxzAIQq5/////////////4ajVd/9skZSMjI88DN3QFAR+qMGxXZkJEbTIgNRXUIRcbwx02T+ISAjhcSXJ2w4TFhG4rNP/7smQSiAWsU0WzengidGoo4h3onhZtmR4NpfHBuzGlZFMvWXI+SKaO1DskIdG4eQFgWaJlzH+U9hJziS4mBryRxmD3ZCwlDZFCSLCnT7nBUEreh8d8w4lZVI0OW2w8TcnMBxzv6+ZDfXUNTsbUgWN/rG///vGv////97zvODnL+h8A/DnXLS8i7+zsOffL4SdPJ9kMwn+D0mjyTJMSZfM8dRvyz1j5iTMEm9pPR8wvBesiR6665PMb/nHFQsJQ8LiRadqfFnLULQuFYmqY1nFNf//qdXqpV3ydiHoCXGa+9tfPv8Z+HzgnPm/zvFNdSTRF2uH6ff65uR3qSYDpfRC8kDH4Te8TMIhdKVNokJ6bpvP3/PXoBCnDwQQVihg0YIlIHNmj4XTV1nV8BjCOauoFlyYPDAYsjAzEXnaw7DFYdYks69apq9yGSwnZIyJsMEDrIDI+Cwy7UAxJMqKAOXlSr2xG0W0neecjBKJkxcVtI1xWKbNkkFDQOGDiOvBBdpD6MSJlQ+2XefX///////////zpiZ4WyTxZYjV/+umSSrmyK1aVr9gYGxghby9fuUQ5Ga8jJrbA37ftbE4+y+tMm8ofO2Rd4zcngYBul7SIh6FC4HeJgfoc5KHuABhQa1C/fo4ml7EKMfbkfIyEEzsmjIJ/xEHGB06Q6Yya/aO+5sRjs5+U8f8yd/oEU7aCTkPjxHuhxU61+15vs4Ofv+GVzH87O9GFWZMp7D9njtkUh1CxM8soYmdHSePZnTzdJamRT/h++OoDMN6zAjWEVEQokkgBwVAagSYkpczrJ8Pwy02opm9bThzxNx9sbXOyu5om9//7smQUAASZZs755cXwiYxZzykP2FLplzmsiZ6CVTFnvPEyWHfRY0rfGrkFFE0iYm6KraIhUYQIooyo4uikO4mRmK6kfsp0Vvdf////9P6f3kkIxLqHw+Hw+LigcYTA48BAItErYrhllChm1J+HVYm/E+vNe9y7TewJH9SxFtWMiCoMganGRKTtCphtDz3+AAnBshgCJZKB3q8uCALZARhfgsBeCwWJ0Qxz33812Hkzfb/V2RRgiC5BD3CGvwib98uuk/v/stPcD4k1B4iCgdlByHwEwUBALuH8h3Zb9zcF3x/slX8JN/97rhgZNMbjHa4bkwRJIdmxQRKnOdb5UFO4PFpiVC7IWxuFWekfGo+GOOxvGS7gKN84ml/1kbiRaAAjRxhiUJlhloxQtgEmbO3daCVKeizpFNR1nMWfx6L1IsPBU5Lqi6nIl9SB7se5/3KWzdi9JfnreVSR1JdqW1Mq/L+MTzt0mOepuj3jVs2qbGp27vQIq5FVf9P///+j1b+7gxbH+dz71fnk8vz21fiSnp6wKgHE0x2F6aHaE0dGSq9Uc7eW7rYHNV4uu8cQxgilEREIlbjJYf/w839IaQpTGYOo3jpVRGzMBdEJZB7qiNeAL9IQGDQRykUX+Z+cJB64YrPSOV30dG6uxv1l+PYPmd2v5SzH3+8MubdZ+X20NrNNPTVwpdH1yo9U8PsQ3YW1ZeP6rb2Pljg6H25e/z9LX++yylZKqceiswtJoig8bXJXVcW4PmLKIcDtp5jOshj/tBOVKhJ5V5UiLuzABoyRBYDRsOU00Fmsl+1lP8154EzGOSxtZStRYhNgoFyYKxFbKf/7smQWgQTFZc7zKTvwkQxZvzBMlhKllzvMHTlCS7BnvPEmyKFEDpEYFa8IKZO9DKR8OCMSE4qxpeLbLyBdAhSWQkyDohXA0A4wysFWhwTkSCclspbV79v//////JiYfmGK7DxNxqkHioTCKMjYJBFLGq5qlR8eeVPBy6nCWYUKGDcyomFoUEg0dG4nKEoSOADDqpiAAcAAATM4+vjJQpOUNtecChZUeucazIIrJ51FsdC+VTHb/yp/9Hu7aWYraH7naaJcxdirUczZ9h+kOIXtVecVuUjaiap61eU+TrtjUSks37Ld4O3nNWEht6yw/plYFFY+RJCImRHa5esXOLiw8SFBSDm65IZNGahDPI+QjRVTjiVJ00d1+/1Xr269jXgCNDsZiLothABxGDSXSXCNKtRbtASvIEEUEdtodC2KA2+d2GIHszkqp4/N0tJbm9577ZnJdK6XPGrGCxpNDkESPKPRoKhwgOOXEcoNgzMEgaDUcQ4opUVFkQc69nIPU9f/////+obmas0EYrTkjMTOlxA4hbRKxQWee9LGpE4gFMktVNQJ9J+EWWFzZFEj9kDAxI0RvALmmhTZX8UQAP/AKYPRQEwAaAbxoJBqVwoMyQYlZJ3FziJ475v/FgRGruwx8EBHAf79YSChxIpgXLvJgZUkSihAiJ6OLW3Ov2F5f5GCJg4xBRlKFNX/NpLJebc53Ex/YrFfUj9jRCwRpq+nE75UrE2jmeQHDtoVM3FiVChOFENaKOamyUqSbKqBBjJvzs6wwnLBPTRoh5ZUKJpBEAKESNDpoSUG1EhIvQFFDFnLXV0NwdRuK7YnRs2iU1RxW//7smQVABSQZdD7Ak+glCwZ/zypiBKJl0fsJPHCOy9o/YOl6TGc8pRynpKaYlcpppykrVObr1asx8Zw+csUuPMsqSV2viGeMsmaSP3cs+VKWhld7tmrN2J0+Nlf/////9RV69cmyc9ptH1qMPRnmNqDlokE7ZUEDBRRAntpYsmmie2XXbhXsvIowGMbAIqHl1MVQCAAP+1AQiRhhqULoXYhKSMkeofC8QppfR1MyoCBZUbcQFh4uEDCr///VoWWM5z2ZIRZVW2G3pnV3I1lWZMQmnUIJ9MzbGMNLR1ducCtsNRBTJqMdMiLtTETBRGdTksitIyw1VTkjlWLyRLYmXJSY0WTkBtsoSEphQQDjKaoTb0jtFuaWyBZVp8yT4Xm6Qy81MGpm3Ek2ACBNNeIGnMZRLQjEXoUHIBtPQGOzkqgwCGZIoW3a3TqrkYrIxOQEsCQMEMkY9LKcIZkmCUVkInhitrVD8sp/N6mU5iE0poFVmmZmFFN32S4plDZHsM1vG/mf/////XV3shjO8gUJOPjSSMEcVupo4ehwqGpo3GDCymDYUjcEyhIanCOaPLVB4w8kQL1aZks6ubMi/rPAMmQTpiOg/mj212PyipMSuvXaNB4mEYoJdRWwrIjw0G57//9KGHzFcyFs0lFW1ITknK1rxA5+ZLNiteypU21vI+pKkEJZpj0QLl0fl66sEjC82ru5QCzIbjsCdhjUsYXnIyA6ARKggZfUlgoHhSRZAgKCdGD2rokyxtpAk7/pc21BtM0/qo3aKhyJCSZIFAEj2KgU46hDRKQBsIFjkM1rsRf14oMdCujan4GBuPfuRyIy+ehqP/7smQXgBSqZdH7JU7AjavqXzzpiBJpl0vMFTsCRLEpPPOl6JOhjLILporS25XWrYXqetQ1IlSwVHp+lo3DrdOd5iyO48TYwIQ4CDg/FDCxxV5Xo4fa8zshsRbhP/////9GtLcxHj5mFJijDCElNknHRzJuFheyN/Ttdv2p3rRhlOX6DbnFRlpBBqmhd26tjayQAA+ZDfPRUWyB4HSeoGYIefpMwCwI+A7lK2IpRliafIOBogBeNAXi8+T//rNLYelkD25l5YYx5JNeoIrvxkg86xu+kpTEOq3kXXd1aWJ0jD522JwqSSGDrPe76UCet7rh24r2cjBVAIkZiU0axlREcncjCqE/QyRoVHw1D4NZJO77oSQRfDZrF1MGbE1IICAyMbLESzMNJUi0gemKBAq2vqvxTWGfdF6ioZMDm4thfpY39aPSt+JXbmsYap5XnduU1mCqXKXTOV+BIjIJkTDmcRIJjxMOOofMAgicFD5xIhyC+lUVmUfIdh3+z//////pp6+WYssHx4VmpdFrDsgjRLIFhU11W1IbZ5OElEeEC+Z3CiO/Vack2S4ho2TBgIAwnet0ieHFARhYlcRlNzoidOoWQ3cn+eJBwwEaCOE4bVP/roCB8sZg+Wm6yaOQ4dHBXiUEddeEl4NKoFm2ljC9oItqLJrAtpGJ2GIKEFmSxgkim4TwLTV/n4Kwf1HnXU7WsOnhOfORJzpkqfmNCYuKCJIdKHxsG5GSorF6mo9BHim2+m2qsZjK4f9LaiWFmYICIEGAS8rAp6TSVQQtkPWMpUIZucwZE2K334Yk8Mp/dPe1MTdfPObjUtnvl9+tWxoO1v/7smQbARTWZdJzBWcwnCw6bzMJOBHVmU/MGPbCVDBqOYQluZmM16aVzk5ZlM/FdU3f/fKTUqpLEVCIiQaWHQJDgiBwDQ7ibFAcSEBdRWx2f/f/////+lkdL2EBWodJ5eNIBIWS8Pn+Ss4yQjCZ5G2PSRowZQ3Yyzoflc7YT3RGVNfLzB62cFSIyab2GpVK4AAAbX+kGhEKmntWHdRwrFyllCwCe4rFg7M4WM2gKKu9yJ0BtC0NuH+Y/////qXqW+//r3KOQqJIWF2VsgYXIzTG/EaNPNEGU6dFOuqyhSNYKXm6LeZ0UabLzJ+QHBOLihaaFJyBj3a6vm5ZrBWZol04RohYcCg4RtDr1XkbYqJSRHawqMM8kEDvRAgNrG14mJZHun+kkPLy5ogogjesISmRxWc5IoAvIuV8G8UxhmhWq8blqrNOcJ35DN7m41V1z5uceCzX1PFFHCAQogpMkYymUSgaqPf/g14OWYoxI5fWcanhpQTli4LB8bE0////////+h8aWEoKg9BcgmIocbMFZLRUmKw4KzHHRFKkCAhIDolj4iDQ8F6Cg0wSyAwcjC80SGGnmZoSMcE+4BrA0bww5OvLTRWCnmr07zbDSkmCT//yw6CwoH4oLirb//u////xRzn8Pg6Cj47ODE1rQ7aIKObI9R4nDGJQFCRslJEKSEyWS4siRwOESyIk7YDDqUsKNidcPy3sV+mS8QQVZJBwZIiK7AQyKgaRg8SnkINLJiUGCWyA3A+lFKVH0ZBDUFywraMkiI1g6ona34VVT6jgc0Iqy4vOYRCdB4pegXKalJbAIb/NyaI5DCpa8C+YAlFFKf/7smQVAARGZVZzBTbCjQwKrmSpblMxl2vshT6CcjBtfYAxibNPejcMUl2vbyvRd75+x2GH3tzUr5jamKevjW5RAOOZXEDqUTD6qzuQUUx3MIASxEQhCM3/P///////TJPvTeWna1s7GYbERGX4iMlPbZi8MQQoxSXQQSTGRuzIklIqLzPvBFRAUAImydEELmjwRhAN3CBQH+VzwYrU+ijsaeolaLCARL41Y5TmZiE9kdPw4vVWEpBHdnJIxNZi5bGSjCjmCRlmunUMlUUVJJQyp3XnNdxDBO5nkbQs6o6bxAR4J5zG3KYgm86VbNrRRJFdyBsRoxs/g3NhfnidbKcygLqKTuCxXEpOjW62Z7Qu8qbqnVkbVzASS5eRYha8qrHJAECLAgY9aYMEMgJrpZdbT2uA3R35fI8Zfbibtz8bh+1MTl3888M6TDkrtZ4/KIcpKTOnt09I/EchzcklkzyX/DkP0rhsrn2nrvjjDJbE43TS+UmIBYhmb2Sf/v/////+YtsNcuKHzbq5XaNB0ock3/ZMzRiOf2Z9iBBCJsjJEDCh2pwwVo+6qyd7uAHSwzMgPOyzCWs7XXDCwkiHRAdCHBfkzlqEscpZxhleW3ok7ixtruzb5NKdMzM3czm7JFhmrfPzhYVToC5VdLRoan5+KxqP9tAeWUHBpmtn985DvnP/v1gnLwiWf0WdeeTn768/3Gz8/Yows6nfT5vLDj7d7Q/1lhLVsHlL/ds8o4vyGOm3s0TCZW7FIuXv0Y6lPcdf56QinmiLzHEiKBQAEYCAYLDBYZgAWoXa42OLgxtOEzkCU3Rp89oHk5JJswqPUwfBo//7smQWgAYDZNjzp2eiaasbrzyjbhKhjV+NsK/Jep7teaCNUBiCwxBElAUo4rYGAAm+1OggBzKj8sSVAxa3KnxZZDcOvPVsxad5Dt27c1R2X8d2I5UNemr4SqhiU3OOtDz6wO2rbPDGJS6TiyOlmLWP0NgwXnIzWOSh4kBsaDjnHNbR/p/W/vOt9t0W29s9P3EKPK5/twB7Z9m469eS6avmKhUhK6plyNY2ezZMcmJ7zUdmlylVRC1w8xwAZyJsgAZYxbqB9iNrg6BYF8t59lK+Vn+SeQ6uUDAQGjhFiHIKqRkO7dbtqJYmKiYYBBxqBKqQezP/zLE8BkbMuQUuGs7V2Zv/2h3XYyNe/z6pbHxmbzVG21qlsd9qwMSW0OtnjurQ14AEAAEAWAREBvqQH5cgywUMpGjAQAQDZiMUbXKhC06KaaYYYNs7coTBGDkr0Mnjqh0qWRLUPVI5FJ+WbKL0cl48EQm2o4Oz0C/AoMDiLVpHXLz85gYqk5qjJ7bMig4VwHIiqkpwFb/9/9zf8untrQ0xucFRHj1FHB0MoGcUAxBqVDryC4kEKgg47jBw+t3ERAPdBad5NiADAQUQYgnvQpGlQqTi0eyzkYRdBoJ5DkjfoFCgjgZZNwzh2lR0rF/9ePN3csvXZkdXpMysme+/b02Frl2f98+f5/C4JQsLvkwiGkBVDfQCLVHudnjw8As866DtkyQAAAEAAALADBaMoRZyBEyBBREOYC4bhlkixoPVjoaK5ZI0EzeQBgCr2QOPHopL390/jibpL0Yp6fTiv6sVrkhdWx13a0pwuvy+tewwt4Y0o1MJAEEAKCMcAsevRf/7smQvAgSyYlf7KRaiXmwbrjxlWhI5f1/ssPHJfCGu+PMV/G2soawiLCyN5zIWz1EE2aV7v0zHo3//////5i/sYDQ6i0M5S2czndHDusgmGCFoYM5Q4EVXDjh5MtGQyADOHqvLYkkEXgt4ljqTUAch5zDFCv8LZBZ4iuGM3YQLn//VjOsUERcXgQeKqQhJCHsdHzq+qEe5GVFrujfo0awm1Flvf6Kip9Hp/3ief/a7aKzZUNInooiroLSwCIAAEAHAQGEgAQMsdYACuKgEgpkkABogkeIwE7Q4gBrg5M1hGeT1Zc5fMiu58Lbdi+JLJoPReeEFOeNNiWJNFnkEzuggRGp5hOqCY/HwcjwXLmkRhCvWRILi1evO/aLBnWdalr6L/2ZxvS3//////+aU/cwkTdTywpHTtCDStDRx46TInq6OcYbPC44HSkSstsjMoAamCCIh/M8JdCcnojWZTHPpCL795vnOBXOGIRaHZ68w0Ifcf//lRsmHrv4LR3DSMNDDHthO7D7WeMygRQ5Dou0vUqO55GbWtfznU/6jjlc96CkWTy7vxY5YbJVqiQEQAAIAAABAC8ygy1wQkyUYJFiUmmYiIgVKCswgGQZcICBlx1vl8kJ6EaqRqJg9fdnFcZhAWFpi+qfdMT88ITiuBc1dctk8htm8nEpw/LVFxWOzBqrMTh2ZcavNVSW1s+6W7HreTOW0X/+3////91b4UwCO0WIYWBd2qlD1CAbAmIMrkHUwQhJ2YqgOYaaiCDJSrROwhxFQgE0ph3DMEmSWeeEx+3H5qv+fyKNjS67n5FWECrlyqtLZkvNLdzxqck6jiHUA2//7smRjggRlY1h7LBRwZ6jbzmEifxPNgVuNJLxJgjGuvPSJONyTRCzGMZ+iJqvXxGwgsMb+VwzgIU5tDHenLqv/Q5R+w2z6lHPZEAxQ4a6tuisAAAABBAc5ALKIoIS6cBfGCzAgAMEMiEKABmwyAQyM44JYwLs2Mc0oBeUEOFDM/OSyGqWdcB7G6Nfa+xhOpEh4IvRuzam5irVpbUNVeULDZibh+fhq1Gn0qWY61OQGEYECgLhgbNdodaPwVjEkYTRllBUaT9ynYe/8iKr/////VT/UCiwsK3AcXm5B1ZFJGhwxSlD4oNVEUUGFEhKLLdmDCQARBJF2Kg7AzULBdKBW5ycYtg2SMZEUq3/UsLhgfvd9f5aML0TsZb4QZDFPVwZjBWdTASVVW82p76nEs4zvb/MPCIUId1ey/Ny3/5fQb/+rfXv+1BMEK3CVL0Y/wVXcgkAAAAMM0u0LklpEAEhDiSyEKwMjQkMpGFjQDDAiwQWyNCgBTDn0Fsoaau55akejksuN5D0y2RkC6E8HDTMiVrCVY2auElpJPUkG72cMSV5qWjvxGczoq9aVV8Ka7LbudmUWvsXlhDkBA4ghwZg0yF2QnRzEFAD31FwjBG+f/7HYV8zmRFKGKINzNuOfKBsy6OkcjDJFhaVARvPSVWsGgGBMCTJK4h4sgVQmJ4jwMcvGD+L+auY87OMqA13/ju6muVayC//tIoIWnvdW41DHpVpNylL6lQSId5gxx7KxQpjFZ0O/6ssy1Kl3//T/16t//X9v/wTwateZuY6yHACAMFFDBBSIEIxDGw4ChjGE+E9lIKDKxtWFA4oMlo8kEUFCqP/7smSRBgTrYNdjQjewX2r7rz0ilBKJd13NJLjJmLAtuPCLED60tjt6DYDpn/uNZWBaGu2y9yly42mV7Gt80TxUZaNEpC2HgyDpSLCqBM8H1oITujbdtopJr1GdKdnupa2PReM7/Qa/RCnSaWqBjh4cLB0f45//GCZz/IKGQxzoodGcrUsUh3F3iZCu849w2P7uiKhEMyAhYBbPHAHgjQn5zE5TTgzHwnxYEQxKqKf6tQ0fj2dga2EsBM3B7pt96Lmp0sI/HCJ/Soxj+kjAEdw8kACGTNGQb2dhRwiHZ3+6yKxnBOVjTv///////5v/zNpQncKMroJISqr+FAAAAKCAwgCOiiALAgQzAIpsjEEVxAEAI8Kry3BpEBYQDS0xZkvaB7DNHTfh3ochqbit+wz+Mvsqm6yND8nAARIP0hpMBiYDgWVhkeunAjKKJywenjjiu0EZcPYaFtk/gZaV49V15FW8r6rczWLfSdCqvUUpUyjCqxGKw0g/zf/qpvnKeYguokUj0Vqc0xFxt1UOAKJRwdAYWD7phpZxMAACABLg7YVLZMJBgIAoZXAXY4Ua7tBkTMFbmDdi2vZ5EcZrZvmeAp3qFPz3xFjeH5wdVESO5Vv/dIM91UhqWywVhKqdqsl0ImUWDZ1ob//9f/6gkoc/QFxh+jKIREmple0QS0oABBRZgtbLptDijw2cgWjkm+reiKMDL7HHKR0ZPkhfLS85gWQiGJJsuLZdFgGXo3rv5WrFY4WCrE9LqfKffV6nrsSvTXtrMOvZ3GEB5R5SzDHEiVFerXbVuqmuw4BgTAQWN5f/2Un1aQcEToOOOkcRauYgkf/7smS8hgTsYNbbTC3AXca7X2HiThHRj2HsMLGBgC0tePQKKRgGYgqIWD7CA8hxxRZ0xA464IhEAAAAmgxzjoG8OtuOBMW7Ifqpds7tRKZRHwcr+8EmA6JH9FQTuJrFwBCiTdOKb+DR9IxZZcSwj7ljlKceyAjvS6JqyKSW8paIXq8qfT////////+jb4J8hemr3KfylUAAAAAAAAA65zSPLlIsm2CBhymKKVkZy7hpsAJg3ygOCaP4aqdeJhoKc2SMFYXNQesMpYiA/MXlqjQhAUtWWrWrriBwCBgoKg70uz1uDlQc4TxQy6dhGlq711YElji1pDbuNgabSxeFtqYAckMpF+44wKhvEZE0SoH6k1C0eb4fq/kOf//0m25FMZZTd+tn/////////8f//6xZmKZ1MyazRSsc+eDQkxVk2ymtfUkR5CL+6qn/Igz8plVQAlBKMddUCNUFDS8iyDmpSN6xQPW0yA2GU0plnhNr1LSz0WwSttqkNyKq5/+hWzsuCEw4AY7hzj2WTcGxHZY4YYDEGUCAt4oTJKAkW8otn9GRz/1Opxan/0uuCEdDvSU5G/0Fs0KcZCLUtApWj3VXFIlTULSAwOhYKA1egQUvJcqH6dJeMQKhEENAXMIHEYIyUcGyQ4kZMDTHepSCgQzyMZXIYG+DvDrBEJUVRKhVHSDAOYh7Cg1tEIUuYChPgZhSJ4upapxUjTSyodHozsajNBKHzCVkTUVfUL181XfQnd5n0HWX6l8kbcZhc//6DYvmv8fb////6FlEUoTEcmwmoYMZMShoKweC5gqRG5s00SXG6iw12PGfRNzDKoACGCS5ff/7smTvBgXIY9VzO0vgcmvLr2EiaxU5h1dtPPHJ3a6t/YYdabEU+JOmUrINnWdTV3wR1bUur4CY40DUZzzReMCHCUmX2OM6T/Rod+rdHs5phynlTRc9WNKFooSzIVeLh0xY4ymtebZFEKoWfORjPSTKkP5U4SzDlJaN6COXZ6eKBsIjyRzkSH+hpc9FMQwqdopFWpSEQAAAAAOA8gwBEQIlBvEXMSfWW5RCDKgxV5kSoCJiAwDRIiCmsFATiaUyCAS2E61nsJWI+69VpwhpgqATrR4gV9hIOnSyxcKNbkNjZPCpl0LUenU715wtTBlbjOVHk214PY80PufAsO0K4BT6FQUqLfWSUeF4r4eYL44WE2x1xotR//6DZ9Cbc8OJ/////1dmHxxT2PRsUExq6lCw6KzxdEkeHKKYcRJDpeij92yyqAAGoApZI1SIJfl/37HRIwUj6gwhIlxWkuM6T6Ps7AfAw7+TYaTWNHSIREBCwwNggaCbCP////8TUTU09xMxLJ3DeyTZho26IxcyT0elLNxELA8of8EDT/8ae1V//m44zHf1H+1xu3zdjzqfmBDr3/50sfl2WWkxCAGAR5LeKVEg6XMEgcmK0dFMRgHCAYODzOhYLtaZpeEBH5qIIas/HZo5MMoywMh1EAKgAKC9A9NWSs1WWnoXjTpalCGWq1g4IDBJEWCVkuWjRDyuLAnApQIQwQGMGOeS+I0ahxJ01i71XmFdHSinqabkQcqfk+klVgZVbSVTydVuM51oduEnnycf//5Qa/T////+HQewsYeoSuWqFxOw3HAqYQNjY6Ya4150ZDIreNyozcetQzAkUP/7smTwBgVrY1XrST8QeYtLb2EoeBZVi1OtvPjJs6zu/YYVPCUbdaMy1W5F1uKq7M0TCRq2wl4SModA6vgIsXzT6u2+v0e3+VNWPiIjmZ//ykUsXQzOolxh6rMc4eq4HkHDWEcgoJiGYj8YOBfUeUT/2FAcu6kZB1DdilWrpYw4go1VRvYFKM4EHpWwBAAAAAADABwuSgJQAx6OGKg4QJCgCXMQMUDLwGFkJphAZGIJ4mco5qQKcSRDg2BQxEIoCkblaUSDBQZTFJt1XcR3Z3TLWT7WslHByulrMFYgQAJdROJWJaidDS3mVuSBUJdtn8aZUp9n7LcHIctyWuLyPFpgkIHEMDzQNFgU1PqqdN6q4cHFQpQfq6lWE//+jO3/////1QPPqJi6GK4RUFFFCAsH8FQRF5DZTCIiMFmUKEI0XuCVgAAEAAItBQdCtEkK6cMovLqXyQjiNdYKEY07mR9pw4G9yFWnD+/zl2FI5HpZu2whKS1ScueJ7jM+E6uBl0WKjl+xrrx3sfPJLT8mytqOU0Hg5Faf5oebv8wwl/e//+UYdQ+H4bxQZaCIcjoSrCo84cg1sz/FrhqxgmH3CAQjYDheqwpMssEpjwANCzITAQtuIVSgFRGBpJQYmFHRj7WY9BHCgRzoAGC7QmuixHbR/Q4oIETn70pFzgMGNoqP2qNbbgkNBJyMC2F+IZqHNKacmAYMBViMY8xUsZStfJVFnjyLBQUn2055ooyWGYJoWGP/Ov7BsdkUEQxD9I/D+0DlSerjQ2b9J37OHlv/////////+EAaKuBzRHGpk53odKjxQtoGS6ikiOgmpomEsbi6of/7sGT0BwWuZFTrbC8QfSs7HmGIhhZ9kU6N4PHB3Kgs/PSWYBGJABDABKRMFuCICqTSWCAjUURasItp8B/lUdR4Rj+RhN5KPObJkC446WlHBRG80yj46gjvZm3UXqbNv2+EnQjkV8GgcTeRF92UOIPZJsxULLGKYwUPbVxtW/eJjB+HBh2xgux0inqXGHoLMhBzxFVNOy8NFyzRAAAAMAIARwCvLkRlMBczLi1EBMwwIBBJUQsxkjwaSIGSkxl6sf8bm2jhm6iYEDGLkgKF1NTqgCAErP6FSjUWXrQBOAG9EdDk7KTqgpFZAgFEHNqEJc0qpIWJhAYScaSyRQrMI27i80FHFWYrbFWtLLFUgYzS2BF70SH/UVeyNSuCuQVnGouzVcrgrSZQ5T7RfP5Q+lal7//6//////////8bFBAQrllBdMLfqwvFg0czgLi8qIY0TsFoBkmNh0pjEBBAGG041eoyrMBVhAQHEFsigVbQVS2F4l1t+bJDVYjX9/EKAB/7RTJBOjjVigWVZ2yAsImnADHAsUl7izmsXrcVTBAmtxpIX8KSX0quz0kje+vGs2tiKsQIEe3uBSxpv/+NCyK2Td/9UpguO/5ZzpLEU8QMkofEWMJN4n8oW/8aq6CAyx80xyQZESU2YICjI2o4KMOFC5c0L4wwALhgrIORXP0WOi6DgpgxJggosJV2nQg/XSBZrDK/1HValJp0SyXiRn4upckImpBS62JNu/jL1kRNhz91LiGJBKA6gXK4ImBbK4pTnRkePK2h7esVipHCDsSwhAFIiQ85TCX///////////NFg+P9Cn/Kjg2LIxoqeqyV//uyZOwHBfBkUkt4VHCEqws/PSiOUwGPUI0w+kHErG49hg00R0i35EOxgKIQGmUo3JLF80/owhNDkw9C1FRaDkS6kJwQRrEXk9pgeiayZdafhoqF4hApfG/Q7mYArsFOCqqBTa+1ZeGht14GPh/2tBIL2iCDgcMFEf/9NSDOfz5VIM4v3OahkMScwQkYvEDz3/73mgEt/kLAAAFwgULDwMOAQwAo4mlC8fcoQigGGjNSU1YhDnY0UqNdlzILEx3EMVBAMaAoDCHo6wEFVABaoQtgoXjPA5aJxWt+xw6zzChPUDjDQiOIu4WasEiGIwohhFRUxiSBhPyJJepkbTngnHqlrvOPH6eHVglG4U2OA4EUVYjB0JgBnEdhiAMQyC2GwSojj9qRRRb///////////HcbG5WaNWmbv+sxNB6olRiXSiWycQn50lGiUIwAABAABp02KAQaP7xstZG4sPvy3fgSsh6wSwsY2QPpHLzz+RTOB2E7UWHJRuI9MQ5DXXiGsaC2pNxGxhZKNyhxmQPx1INhNO3NJt6Dk4fUbQTHYnEv39f5YcBsWVMkY7Uh46xWXvjyqkyVb2WfuR5IpMyPQ4QRBu1viR1l24cR0PO/+LdoJLoavqcEdluCPyHOLggyYMItFhyeDrg6uglBJIlHm8FmwFEM0ywUmsBjgoKusuRF6BFpxRsDN4EMQHQpQoXNFmaFmkrVcL3butdK5oZYFeTAf4noZyjIiLLlTKNSIFweZQ5MsaHMcZaX1A4edS9/DTlSBAPECI7////////////0d7ahX/HMcwfFA+e6psBYBAAEAIspx3EsEcEGb9HMWJQ//uyZO2HBZBj0it4bGSMS0r+YeheERl5UQ08uJIbLKx9hhoZwaOvuzpMGcdYqjWyme1aOXZpQyOlip3TjOA+XS6DQqHkT0md5dKpY6WcEHUcJzohYyrcrM40k6FfMY4tA5PG3S0nuMo36iSSVsfD5NTotLe/746ur71arx3WWy+Dd1plh2zf6Zy9gzDlar//sECDKWSRVjgBAAAAAAAACgKmVuCwZR8y5oIAwEuoRihAmMmNMgPNCOAwc4gA1SkCNDoogUbNOLDMQ03dR6EzFQt1Z+NBHaNOSacgegJWW2IYIqXq9SFZ6l+wwxIEEkJYj7TFuSQIVg35bIx8qFgslY4ZNia+PxeRF8HC51jEcLHz6yGjY8I7ipjG////////////1dSRIsYzlWxdqERkocqlDy5+vahCI6QFgAAAAAQIydIX0F8QYLlEMSaUqRC6OVuC0hIt7oqSiEfDBAnvVsiVacoYx/8zuyOWO6qRnDzATBxkpk07QFzaHh86sODqBsyLJcTNK78tm9WXratRcqbdprWtisT11yoQPQYbA2kWNAJtxJkLPnchXvriwAu9E0vAmFmeLv+FXHgNSXYbb0xAWH1ACMAAQAChlQOkQWLQi1wmfNtBqyjKoxIQCSBgTwAXhUqBspxX5QiBqs89swZQH6GhqUEIyJTwFxC4KKYGaX6CtC2SVZeAOYCTKWCQy/pdMQTDsCAYskeBdTCQFMSfuGtT+5bFLrwvjDc9EYJfWbaRGqsr3jQ8lNJzVMIRECcVsX//M//////////1LisiFTJp8cYfFuppEbBUWKRFZwvMYcGmjIPC1Joo0gQKms0C//uyZO4GRQ5k0/NMPpKMyzruaYO2FMmTTa1g8YoRLKw49JrB+ACgFifw3yAoMvocDOS08VYqkmny3AMoRRdGtKs1WS+Z6SpVqcWE2EQdGB8XNrroZxESgSuu6RKcPEkunZGD6yQPSYIKpcKxg28nrs0+0ZurWkmyFgZ+vGTW397QnsJx4VXyc53bK3+aJ9tksZ/zntfjwn3ly+xeoJf9yQzIAAA0CeyBFaiEGMSCQEbOWmeLAaDgOGjAg4LDgEDjgGMx00DGkykbMsRjnCIgKs1qAkIgRbWiBtJGUBqaMADjIXl5yLwXSIWFBSIRaeDlzMNa4ucYGwKMIBkumbsTZbLrMdvS2Gc3onJ2ansHSiFDGpTSx3G7LZz6QLGkizhAJdmPPU5RLdW////////9C/HPMJjUXikwJBEkxXE49zBYXQfCMsOkhuJdFMlBFDQ66DePRaVSIgALkdlgCeFkF8+tDZlWW8QGaesRFFTKjhphr+OdVpIkG3o089nWaJEwHy9nvmVrXn//LtP+8xpibiuYitbFtyhZtH7UjQ64XEEYpTh8XTn90K50OMoKDT7oZCIYUzCTs2n3uWdPXcZyX+u4JkWAJwJCiAMSlEyy86GRaogNykRgREHEJA0jA67gCqxG2MSgP1+Ps1Gvrcl8qcpUu5XDBBADTmMiEStL9kTx+15IrKwmBDoB1DYFbC2NbYgA3VD1vvMxLDBpw+FzIGycnEwSH3E4bbCw84macFHnWz0EcFQvN6KEnShAgIIvXUt////////6Hak/QZOMIIGhPII7HkMeGhcuPFjh88mNhkTkULHjI1Tta5hjBBCm922b//uyZOkHBYhlUyt4PGRvCqtvYMWMFQGPTo0k+oH0sW49gwp4ciOl4m1AKLQVCXygFFxnrdlku+utwVZm9d2xy/Jv1KH9a+yfA2UKpzVdzapnM/s10FHJoXNrMAyBELWChzCJs6aIbf/n/+vv+MmcsSWwbuKg99IxGugcx/uzHfRDaFywxmkY7rVwzynO9ZXqdqNo9//+o9XUEAAABjwwAoxQYuQSAgUdFjUMRgkRtdLRIpGXAmZbEC0OfHH3n0RHpNg+aFySeqrgaHVCvKNF4ExlLAMhCoFAIknDYYDS4ZoZIGrEl419opgyQYgVvUkv1dSgTJ37a2+xcLxXAqemxfTm5aSD6NB2+VLFfvRskla3VYtHkuH7K/zO5+XqRQrFY83////////o0hBxq7kogOC48RLjhSeLxqsVjkmJypw2NGo0cXi44WCITH2z7uZcgQwC00lHGKDs9JICgwuMiE5zqIzKBImQtJRI8BgXMi4CMtDvp77XfGCp86SazZMnzZJWPMUjlQ5DDDkIQYcr8TfvJkkpIVCuKj1CmOUXOc0qbuRrz3K5GZBTom+Qt2GGJlZBNpUc11jQ7kDrUcZZv/6jqcYEQBMNUQWFsjDJAIpASbxYMLWERuZmg+z9bYIELOpnn5sfth00Bqi6QhNsrdHgjzRH9d1kIFGWu02WLkbky2hQAr+eVtL0XeGMMmb56p6LwmXwQsluplAw084sSKSPgWxoFZgGEFeOSSIQNlwJK+mQ0i3//////8/P/tPjxmIhyFj3KnjJMRjSDD46dHxHHACXG54vKigko4XFxAqglA4/uekQwEBALabUEJy1ZE9W//uyZO2GBaJj06NMPqB2DFuPYSVpFDGNVcyY+onnLa09hiDghQ0FTMQAYWw9jq5GsLIAqAZBcN1JyO9h+OpGeg8CckR7yC/u4I6Std9ZKu3ny5aRzrQ+IH0Sdd/NzNtetq++KDlKEA1BsYwW9OuDKiHbaoJqc/q34j+5hlqn/vl5XcbM3Pe482r7ctz50VWmJBAAAAAAADvuNVhQMgJVAWjBSj+M2XUuxMpLgoDaiZhQtgbOAuUAsU+BY8WXbotSLLpe95JSm6pi38027EHnU2a3B2bMr7uzrPWsuJLHvuWKWFv9XpaeWS2A7eGqXC7PVJZdtz9qMO5WvVbvWIjzINx0eHg80qOFlUsX///////jhDxH//yUNtNi9PBCb9MXaytPKdgQM0wYAE6GJHHq5xMw8daQDMUfu0rIygAADKBAo42F12QDgwwLb5VGIMLBxRaaYqumIrGfhYVFt1YKRTSFj85bAelRAHYooQFnVqyeK5RVjFFh0Jt3P+MQLIyCmddsHij54gyhkRqcWLXVHnM95L2MhO6oYOZKLpHPt7upTrLZXrgpZ/DioGiO4olyxhHxFRSnujpFQ5QiDSzXRA7OKRR//5nQYICTDl2GFgkw2xY8wyWax9MlItGoKBDQLQCLs5Sz0tL3Cwb5oA24NBlDMZ+ebJKYNZ0x100wtx+kZxCZCmO/sVn2uRFczYXZdaQU9M3CB4rYmpfqXuW7jD5uXzlC82MkjlyLSi9unwtGHkBuMExPKEgfFB8R3HQ0Z///////FQrV64mxT/zqJoZXGDIobJVtQw54SxP2JXwouEPNBlte6dZFGpF1eA0rMyml//uyZPIHBUtl1fMnN6COjDsOYYiGFs2TVoyd/oH/MO29h6DgTkukMSZ3BwKN6n5KxNQECCEbZMEbAVlyFg+zJpkyPV7sBoh3D47KpVSior1eMbxV8sg8+yFF4Keu2Zr///+SD0YcJT0YZN0tJBBAwy4FB4i/bydIzseNNFxnH0eSCoVGA+SQOXbm0fib1/RsmJb+YvR9iouaWoGnLHSjex7llBy9RV2dLOOII/8XrAAAAAMnHhYQod4RbSIyjbRRDoGCS1ZwOjEIRrANSydPUjMy9GQBhqDkErRt8A8mZBjLR+tMBrQlgLqzofx+HUmEAyNDktoT3Y1ezxwdGTTuxsuHCVHFL1/rDvPLqfefd6dx92g7//////+qqtF5TFFxxUGuzIxHEHjQizlDgtDWKHFaJ3FEBhIcJIcYLCoeCSZJyKoYKZLjUaY3lpQCKtiyDFbtw4Z/s0VkV8Ngo0OqPPnOUVtY+5AhzB5IolhXmxf13kpra5hbPhl8ZSPynk/+M0Zt7S6VBVVAhdQ+1U3a7uVu39mrQhvWiyX6ILEiYolAcEGUpBAIBEvUmiRA5eszcmLJCQIncGJRl4YUPhjYOTIYKFzOcUImQ4LMCSTE0gv2lA7KwSLKkEKVVnMlCyC6wsJF8U1WcrdbOAABvS+w4AMNZA1hFWGkZH1XRMrlUxR+SscqSyJWpma8I21qB37hEMvC4zX3mfWYmFAndn20k8DTYBwNwUwggLAdHRmF0DfKnhSiuJ4NzF3///////VLF8B9M40sgxONnsaKY7ktnXAeEH6HSgeGHxGPz0qRrbR1XauP0Fg3UlnuSRJlVYrZGEDA//uyZOKHBI1lVqMMLHBkatuPPGKeGVmVTI2pnoICLyw5hKIgBIABXCwC5rZl2tEGoNOklIxCSxlNSG0bmQuHE3uVXlMHLKkbTZwuifLqDUhE0WktT4+2YIZIOQO99KPhTk8ug4LHax21ejZ+xxhN1/wukrBvFJUmx1US7R+5qxPxaIxenF476uXoxJn7/resPl+JgJQii+PMEcRP9SClxJWwKAAAAAECQpClcoGGOBG+BApEMOOyQEUHhRkTjLrjYVawe83VEqj2yITtQO01pl2JSvcqc+VNah7VWHp+QyuWUrLYfrT0MMhvxegdBld5cXMBJOfGTZNMWSrSJUvRctGFFv2T3TnyZlvPhaejYyh+jwGH//////2+pv6CYcHqGvDg4iBMsWV0HGD4ko8ZBXFlE1cXKLBwgWHTKPOIq3Bs7MAGKqNWv8OCzRaSfizWSvtoTewVGpTty33A0gGIPHzy46PXjx1qXvUu7dxxxmO5lXd15mjiJlG5NbVIa6i8mlxzKBBhKCQVESp1sO5HHjBxbyMrHQMHOZSDAxwSFcM9DL22UECwxo47UhxtCRmcaYV70O86dZAODfQMi/FhmYG1QYABCM1cMRg34MWMMUIWeq4dGBAs1ikhGIVgAiKczQgEuBpCuxRebLePsmLIP4YT1EM5qhul8RLA9Ik6ENPQwCIC6exVyO1FJJVEHL0nYq6dylsRieL24pXLiXUuycPNRc/J2UilZEVzLHYG9ykviLiMfOH8mWSJwnLnp/MHCAOCoz///6t//mC440eocQIGmtZMVCckNwo5QLBMQNKjxjjQbKFRqEYWQuSMFW49KzAc//uyZOkGFO9jVWMMLqKCzBsuYYJuFZGNUI088cH1L+35gwp8nCqAELKfMFCHBJdEU0ysoywtNdOmWKqzk5SP66E85kVgCUuPB0clslE6GFMz425m1vp1Nl3fMMxgjeaOe7wVag5FGpzS9ZPdZlL8X9ySSqUXZ9sbn188Q1Wc76lGayCI3lPmaGQ57CdxhVwpmKrfDlBorug1G6qgyj2AAAArK7xhgYkXIgE8LJQaGb4wYwmKmQYHDFDTooHGiNHlUGqpByUxCAOHKBJntqzWFqJwPDkWTPSGS0Rxh14kJ6P7zMPZ5PV14JnAJSpi8Bs6OTcTBwXmiAPQjCoP3SWBMRx3HkpmQ5tlUenVokEw+KbS85SLjckIRKuZVc/1T7YvmjfQwxo3HiCjpD///wiLGNzG/opYVCULI2Eow6vyolmCcYaPIJhQOC0pJjg0JlxKCs8uCxfcaERAJUbbccdb8vggFEJ7bzwFM2ZQsI5PXylToSsVDt9XBPQrHNJXtuojPYRLPFnTlrx8eMwpnKMvluSHMu3MW9GWxdc58cWYOrauVueq+18vXU7e//+y/z15nFbjZ3tjf2J8/f/G9vWpHT+4h1TsVezn+fc/vT6/ZpItnxOb5vIVCkyAACABJJChsERNLylgKaQTQoreKHmDqxUl0jG4w2gVXYsO3QsfGLAqBtgeLo2U1jOh1tQkLJwktqTZuTWPUlFssSSJFZu0o8ln0XTx7ERDFHqT15sRlLP78EoQvbUyT9ERiJiqv///2P9mT92a7KXPb+opDJc8mQ3OF5QeKT0DZ4ilxs7HEx1qiFgyAjIOZnTJVRhhYFvU+4Xb//uyZOsABcBi06NMPjKBa/ufYYZPEUWPYewk8cGxIC45hg18siMV+FK1TtNWl8Hly9wls3mc2Y+ZWOnx0gP3npyFS4ug13oO4ZxnLiY7cKOpLOEbMXa3IC3zQ+65sf+vu2hcJg/4gecUoffGRkgmsJlRqmwAkJAUWath0y2qtBQAAAAtzRSGQmHxkiXRdclIpakIUNV1H0BAXKZsiMDYw3QobaGmoxB5k+bVPNPDgyeKw0+zU2GiAqTMdcOXwVdd6lBZyMgGRfVHhDCQMXlixTFqrIHEp+nD5cEpWLKogumHmzN3D2Nppbqx1cpuhMMbRumt3dWvZtotc79/mO7UeqaG7bztO6VWqnygfn++Jf7tUmFLJ5Wj4o3FpNNWxZ8d6aaR4uUomw5ylHC/AAAABAWsGsGWaZkyZN2aTiVUYIPIgp4eFLiA2J/zfXAvYdSPDMwa8+LdR4ZuN+kZ6yRQ6YbVrEeTXRBGloNU1lKs8zSSCUsujsBs4i0SrO70Sg2GkQiBuJGPpBdDTIcGQmAi6iA2Mky6xxCRGnidpt6b0ekuITbTzQQ0JSc2r+i+2eD8zC4KByB2Olc99bdiyGz8+fguf13CBSOc5T/wacEmum+SEs5CDyTw89SLsjuqQRCAEACUm6gjL6u+hwi6YKpodcovxDLGE93tSHbg4DgRAWy41U8j0yYzz04UqUjFTZYFTKxJ7v5a+9l40bAIVHCpAMYZA7EoWwGLrtaTE5wGA2P5CDUyLpZaEwE7YIs56RagRXJs4xn/w63XPP5XMi7Af+X8JndnGShRYziqFCAPSYYHQM/nGgAGALVMNCsVAYCsKBko//uyRPqABWxhVNssXkKvrBqIZSbU0PWNY+wwcQISravxgw8RFbWDNjeBWxMmKtbFAPojSraX4m5VM1euTN0/YYhyZll7tuURtmk9Z5dt3uLi/u6kBd0jeyReoNDxYLbTJE3Gw0dGQJdKxXM4SlSAZgjdszmivfenHDskF5VSLv0pIJFFl9OIRe7L5l+ZDmRIb0UemD1PkuHV+QAAAAMVAyYWLLtLBDwxaGMx8qkt4YiYMzAIpiFCwxWQY8QQMfrpeuGxSGNlHNGoxnsfwIwHKF0hgIJVlMDLkog2BUIQ70xHmyHcwHSbZdIaEKaSZgcqPKKySOqmdGWhRXpRJdoanmSVmkXKBFlYgWUcmVzZ/0IfVO/04Dqp33XdPf79mQ+///mIf/nb//2OTKh+4am/kb+9MdiRrQ59JFPmPSSHckgDT/gNKqoAAAYAIKTi0WIpqBolsg46IVuH1gK7hww2C9dYc2ViSdcDQNXmZc+9iz3G5N4QzGpXc0p6bs441qnLM/jl25c7whIw2ZwlBAYnzQ8Mc1yuGwZsYJ0I6bHg2KH1qGBSj0KXlFRulnVHkK/8Nl7aCEC4nQorf2Of9ProF2NMUikjlM7kYD8iGEEsOkhDEMl4w1JaSoCoDSkTKZgZ2UBoSwOiFADFXP2pB8eYabKZW0ycTqkjPEf1bS2q6lwMVZ+nESFP+6C27LrTDUIKqPG77Gn1lEckQi6AcJEIxlpohGSGMkZdH48XCU8tO1NiKrR5HaO90Rw+6fL+WIVFxYnjxtlftXi71mrraxSyGsNF3xCESHZ/w8K+z/RosQWqHiDiUHpUs4jRCqR5kRnFo4TO//uyZO0HBVNg1CMvNGKGS9r/YGbaFdmXTwywusHwL2x1hI4oGTKVOMHbza1AMFFNt2ntw+2BuIoIuS4E8yilLpuipgoqmEvduMMNSgfGkcUBObj9RybU6Ow6YadP2iqUqrU3+SXz0a3xU5vhXEgNQLE40oMcSbBmMqYjWQiUEQdlUP0ky3eC/4VeO3D//N8sGphRbXr/PJxyP89tjUYwAWJFlxvxCvVAAAAObWEC5LABGIsMESKJtwXi8iBAViIE07jKhU0AlxmUlKqlyPJfN6H+Y+lXHLECt1UXQ7xqG4ciaPiBqWy6cnkabDlqKSKalijTT1MHpbCWU5kBUGb5u4bF9GV7Cs7dcZhYQGMOUQkuJH8okV3Q28P3Offims3j26hGsbcjzNVS1Hw6QOvlsHRUSdvlf/+FHd2OMNFoxB2ooQgmZHZpVDwmw6VRBwkTUfxhcmUQACuV+6sabKkgt6R0cNPoikjLDKlL9rZTvEZVLUkn6ufLHWlMzrd59qNq9fWAkEoA5TprjbmvzTBEy+4TzyljiFAoTQnabKt5ZT+zBMAqXhBfzCCazCQcUEswRnGqFg82/nQRIQTYX/7zLKeCCTtPXiXs/5e2XM8bp/arAJd4ccPLiIt1xgdHtTBHEQiqVA5lNYlJFTVg4OKoxj3gwsWSUdXc12ovyBWvSiVv8ylRtU8/YXe4z8MEabJpJPQl1Uc4uHIIxPFZQdJJjUMm3juyKBg6PGXPgfZjmq1xp2X+p0PRziiix1jkmDo9RMhwRHFSFRZ6j6G5p0M1P//9Ho5OtBNldajiAIOFw+C1MHSROPREHCbYrkcuFh3ECJAy//uyZOaGBWpl1EMsLrR7i1q0YSO2E6GPV4ywuMG/JW19gxYRS6xpZe1Y7IWaDTHysP2zBwBowoNJJssYmoDnnyyz8SoVneZ0ga8C7/sibKW+vERQRKjC5iiRmGXQY/EIm/Gk1okwiKozh1EFlV0EDiCNR9fEDuOEijQbkSWc1hYaRdEITwtE/+W972Bq4IAAABGDCwWQgCt6aYBBh4uTzlQEC0GwYDGcBYcWkRUYAIiSGZIumSZJt5yRFwcBOGg0wJIQaAwwNSPazBoXBlGAgJRLTsQTMPXcAApdiF7DkwnTlrXEBjs0l9CCBQcCK2t8vpHhmTS4m/EOxh4qRlYF0I4MwpCJY6cIZmApOvJgnEA8SHgiHOahl05cowSDgmLishsn1alRAZZJx9c+hhKhIZjhs2VYKioeLKf///8iSLtjznng9DxgqwsGwpJhCODxOVLkcgRagkjhco0uZD0yACCGE4paVSoJiiiAcKiC4E02LMMFjJeJ1AMDY/OjM1JgtVrlAnE+C+o9w5nEQwHcUXzsd1f/1R3MccjlMMcVQ3MIKHuwjo5xWUz291drFayGbEB3faHBzdBWdYMJscPiaNSUqURxwmNEuqCDGF6MCC4izyLAWDeIZFBpSwJlGrsFgHBVbDadY+2Q0JKoVmrSeMxoVGQuJFkQrzqvm2sqcrGcCEu23OgoJS6z8wlpseflNdzGITLrOcpOPSh3XgbRPJ/ZTdirFsp+U5Szc1XFRcRo0SHA9U1wihMeOLIhic5wQNqNfHJN+hZApwEBPDCT/8sUwD////8sGEMLqjhQRTKU1RbZ2UiMCeV7WWMAAQufv6sC//uyZPMHBnViUsNsPyJ1y2s/YYVWEvWFUIykXEmnLCz5hAogIjvpBCYpAQAJhlc8siUerY2Jb14nL7VpxpX/J6iGhNCgbXMHfFIeaJ5Qq+vkZkFiHQ5DnCSNR0KOUnHvdjEcMR4+llRV0ZLK4c1OjVbl90NkmX2ratRbKbLMEgjIYdeqjQAAABgQsYIFhgGJAQQCGRBRoAUXvLXBAOmAVFsFGxkSOZKYF2zB381FrOyKTZwhH5J8UWq1QIXGPNBiyIL1xsYi2rJFqrNVMoKsdVYQrLAEAJc9nSE1a6uFglyCNIq4xnTjEY2suEzeVumpu6TPV+S1E/VtdL9MoolrQ/TvdJIhTtjfR5n4f5mrZ3RfVqz3snvRCepdT15//jUPg/EEYcOxIlI1Of+sxZH////qJISc+Lg7hPBkTcexfWYiYk5ZOJrIkq2XDMe4wCBY6RkftnIUAAIgABYKxiw8IZwpyGXuZcllKWoSre6HJU/LdWvsBSrq9uxyXPKv38ERBlH0BAa1EP/A1E2jCaOuOjFt3LOdYsfTFqRsh0ijhZGIre5AaCwY6Bi3ltgjdXBu3RWcE52Q7syUbE3epe88KpziVVT4MSg25NAmHNRCGBGPuxxOlQwQmTVBSIur8ADyIUMGxgMbEcYYqBbh7rRjWplK5E5BIsGBBYIKixkChk5wUGL2dGGG1EiSwDSV9uAo2patJMtX6YqyLMMRYeAWUEKvBpMsVVNQcVLIcxKVWeJahmiYwS2lkf684t78tydZzqNEkkyeP8xl26ZzvWl0f6+uMJKv+ej/+PkQmAWGQfdv/mt////5Q4mWBURjxHPC48Ll//uyZPeGBnhiUSN4bHB5C5reZMKYFoWDRw08+oHbpu488w7lXGR8cLIPNoL0HIsbDObTbRgjHUo4lKXUdIWQVSEC/cHwGQHULYTOrcrMZgFjRrj8xX77538KZFpWkWP8Rxn/7PGR1v1GTTGYWRQ+lBC3bUa2UN6kdaz1bWQ+sh4S8sGOLF/590GYvrVTieyRXE8Q5XbELYgMKbj4zly4DuMW1G/F3D/mjAIAAAAkJoQAHtTrvAoCTKC66rxQUlqIjA7EBCxZZjKxmHZ1xx3BjWYcXeiK1Nl6dcKWlKqR+GDoJmvNOcObZdAjL6UaGvlORVizpwC3Nm8wmA2CXRURUPVB0qSgsSSeao7FYtnRmrRJ2U7rTt2SkQFrwyPKMty8gTOej//EzES6DP///////BYw3Q00qw0On6zjmg+LaHqNi4Dz8VKuoABKAASUdCnOLssFYsEXFgvdCBicmnovE7l90G6P0zXk5CRULIQPQWF19jrk2LKxXjWwo1uRuN8Ob0mCMFvw5GIlFicisM4D8ua9hScszn+eaHufrAIHNew6Dj8LkN9svPI/vyfxfyyhZHPUvFFJRkAGPARiQCYsBBASgQBImDl2dlZYDASAA5IMODwaAmLB5pKEYolgGrM2EVAhEICxyjYwCDQc1OqEMvcAQEDssMFjpfMZJCs0kpssYDGYDep7uo2G0UPb0Wgjaou9kYh14XdaVGY3TNgf6KuHazsw9HVgJTDk3IMKSef2anK1R+3epGfynkSvdndWPieALzP/lBKE4wrN//////+g+IyiSI4IypBBZEJpxmYigvNdXAeKweF4zmOLBuTdJUIZ//uyZOWGBONf0ttMPqBxy5sPYSOIF1GTRI3g8conKKr5h5nhoIAIAAFKRoZYlCSjjRepYd/p1nqmKD6ulfu226R6IAMcpHZkoX0nGo/vmOpNzlPBOxKvB0tCojqebngJzJAbkiKcv2xhATrybBpIiBBFnlRZIKLfpQTrP9KX9SGEVJpQaJQaN6qqv//7TMKt/pZ6560FFI+eyH0vLBnjt7zEsS1Opp1W20Y3lZpDYCABABELBDVXhMBTtYskicshvFKGiJ0JjpDI6AhIMEVDKigR/lb3fgqXR6mvTeUuV2/MWlPZcPpVFg5mi9PX1yVeWCeOyLLuF11mrWctbla7EdVNKZSqqisOsdqPMp41m//////////1ehaM0VUaUx8bjlcrkE3VCYkLnZAIIuoiVIABAI3oAFBVgosZAFwqBIKNOcxIpaSXyPjWIJWUi6qZfDVr9Tf06Dc/YSlJDPTEdDksnZKU3r8xeItRUImoToIBDwLihbm9NoRMjllUkaKMQLiwv43VmSGuGPgXuoUyHtTf5zFg6r/PypFA5Sttvbkz0quulp6rjXn/uDJnQeTrwAAAAAaXM+GtU04REQ4Ti1AYCCw4xBQQHxosYocY9obYuacucxUUIzICwiil05jzQ+lspBj6QL5GODKFpopfcWSkMw4uIkVFJSoymQJBpKt8WAKaINoVMVVTeVMLAScA2ZMCESAZCRclARUNSUJ+dXExouwXCBg+gED10mFzJw12VBb/////////66gooZxYYQQEBdQwrAMOh90KKB0Y5jh8WGKhTmIJgMAZx28dIAABNJ1hQdYeQyZ4W5zjFgqt9lVl//uwZOOABAZk1nMMLaKDSyruYYiGFYWXSQ0kupJHLOqthKMQYGD5u2QIY+XtTjgbOxlTWpmO00pzdp9ZY3V9IW5DAo7OXeUlVQaLoEIlgB4r6PXhZ0tnKKHE23dDFNKb4QMtseaczWKJeOlRI1kqVVBaCUsR6sWOO/U6GmHO+o4HOeT0lf/yc+uMekq5sdFWLtdyeeIdSZRCuKPWd5DScJAAAA4CpUzxItRQuuDoo/DzWgYOYIKCBC4GNAWg1hDOYLgiSRorBeVK5zo2im87S2sshqrzWMmGpa3dprYWWNs1xpbMxkBLdlMkZfOMuaSr6Qy6rnM08Iu00Av5N2JfJpbB0qz+OSebyqZSjDoqGlFQ0DqCg7CLqSFEDz/////////9TY1TjCB9A8JWqZ7kN2nlPRIGfDVz0i2I0cnohoCjTmxekRAAEBORRuZhIcexSbV8IIVK2GKCT8awbtnKpuGVxRrls/94KKkOZUJihaEOXe5OKC7kakXqoskm/IPT7pRBiehCBiZBieNKsoj+P+wxhJTPcmTqzV5VPa8//fXJArmF951jzURm+Pr7+3bf/2/Pd9uN+dk9eCg6DYaG/3UtiQCoUFAiACl8qqEQwh0oCsEj8BiTEU1Ftv+a2aYU0Yk8YwIYoYatkpqTCk0nFTEWssYcGK3LGDiacLG1ePCo6lYmAXUlrgMRZ23CDo+sbGDFqwNPOg88Hv5L6jxT8t3DUzch+cpLn+2CXTMQl2txSLAcMEkFwRwUYyuzEILBN/////////oXDgqgYEjCIuwDqPrDNnk0JkTJFS0dh0jZKqu9yjqlF0hvHdYlxACEAFn/+7Jk6YcFGGXTIyVPsH9qqx9lBoYVHZdKjRU+wfSrq/2GIhAFSMsVXFTPCkyCeOo5i5C96Ebtx3j2stddZrFasOFHFjlq623qtgJiqcAQRsQTGlJYkezIyJNRf8RMvbuiHjFNxKSr0qzzU9cjauVlZZWVape/+dR27VN8LRTlNu7XP8ccfcC105a3GKfedTLrhsFRQ68Qe6L1kVAAAAwLoLkWusoVEQgBRYa2jajapaosUAxKEkI2SGwULREPmVEQCiQWYhjMXKT0S9SCL9J4PXGS5YkENNh8DEb+ypB2IpDoLJC0ymDO3rQ8fp/XOYHLG3a3J0aIlKwRcLKcqHhuvqqNI7q1z8S2CBY+YE5InPzx2E8P2l5oTp+h3//////+vr7l7oL0H0YdG4EBuRCdIvFBMdJhZRgNg/aWDJRkEoRxaYQYeMYmJh44vtvkWpg6D/tTiDwI278oGkDFUBNKypmCHBW+y4FG1qHYHlmVI5T0RuFnipECiiiIHqBG70NMcsVeRw8tWsarCbY+192Gjks0kk2G9YYMgL+oR5wBfUFdNtTBUzv9xRcUs6IGpS4dWVKXD5CVMFIZMLPrH/BIZmeGLQwUEBNjaQir07zMgTAkGFz4yLBQIti/wjBmMVmLBkBgxjg3rE7dc4Q6GUP25NXSYUNfZNlItJsFA053nZA2Gq4y9yQQlcxFnTRggqkzEo4+qiy/ZTnNvygF0IjFGalapdaOj93C9HCaxH5cHA9skWRReJj70DxgXltbY8V+FJb//////+pnpKxw6PjZ3HwwJKjUTBoSQdDSRG5QtEY8VHlhu5Q0a4sGxNCNB8dCxZz/+7Jk7IYFjWVSS2w+oHeqi05hA5sWCY9LbTD6gfgoq/mHoPiKlKIjADICrrRCQJPOx9+F4gnTzT9bZ24uwixNCAowdxyIwpVe3SijkcdM1I+Y53NkG7Dk8crOvM2jWNGmhiBEiZR8sXpuDmYR5ut9w9l+Hx2mOt64BcK2ZFXZlmj7t/Wa9UFZ5HGeyIaq9fxHuo2ij9ebM+TZQ5g6OIPedNE1mbkAACZKxy/xesGBKLgpGC3EBBw4gHIOip8OHFR0qRNc0CCKMexDp1BolImYtjh1T9K3BRCXzcCtYb5k1GtRwkmotIGwG5saIjtePoedEPwdjgfMo0Bh9ch0cXUcpZpiBW24ta+ppKalKPwR/uWhkjf/////+vNq4OdnUcp2c5kiSMUcgsylcVOOM0inO4eIwxmIIakEMjs6tJAAAAorUEWdRdKCID0Vw0RuRCExRLR2mktIV2vSDVeL/a5L15/ZEjUZbTpoZ0HcYjZ5K99qtQLuEiCWCEQ8E/WtjlqczUU7d4ff4wirzX3IxvG+s3uiWrMn4DNoFzIv5nrSq/7+3bXp/bZ4v6d7/x5cpkMtX/61Pm+aOaDMku5cgVJityyC+gODl9g5KJEnjFhiCJDyq0ZM1vS2aqyogcJNJNDMhhApjCICOxSM3HeUIlcueERAC5ar3LdxryYbQU1mHP24Uaa4zFsbhOtHIHlenZfTcdllWXT3M9zUVxrSyr+6akfyxepZiW366gKMEQiYwjkiRp5Q4edi///////6D5NnOm2dptKp2yWTaJEJwkbxocZSdZFKLDKmJJKPulZGFo2SSwgm0ZpR10to6AAABTKtuX7/+7Jk6AcEuWPUIywuMoYrut5hhoYVBZNMjR0+gd8ra/mEDniVhQuVkISg4rBJ5xGciQ5A0y85bzSx+4vFLO7NedqBy6iWwbnjAPog70lJJ624tpPUOiVWN3P5tdR3RkSRnM/jah+h+MHZnRIxe3l4GUeYa5J5j5eUPmUsp1zhb99C69Lu5EXTpW5ZjFAkGD3KqvggAAAFkpkhMpJBJZwDFQaFdaIA0CrCAggiFOI1MGljQozGxActHg84WlHhk7NNnaWnBFIdjzevy4CZj5/EYDdl460Zbg8jaRicfeCIpT2Lu3XmI9dsyvHsrh+U0tJjXp4g98so5XHqkYz2DgaFRIiQRLiKNTDy1QnLEH/////9TOVEcUCTimdl2qV8Jx3jcVuKjN9sdFB5c2Tpiwki5Jv2OEp5p3igvs0PEh6vjW2PJJg6FlLHdq0IwAJA0qscJCMoUDdBtlyOq76QbzvOyGAGW7aLDgpDxxHGrccgcPGN+7ZVcPh9OQIQYoeRk7bqD2kp2tKMJnytDtZhIgmiHwxddFNtPTQ38tPx/ONhCdem0qguI9dnky8foHpFGcyKv8FSjustH9vy14HQKNBMaud3l6LzyxTk1mX5oRzAgghx5WINGOQYYvyHGYg0ok8nIKESeZqVYGqI6NN8v+XKlrC33c3USpnajconoMjcWp4s/7lU0CvuqVusDP628DuNCpiHLEKlM5L70J1NWL8qpZ3sul2FbVK+sYxxob3yrogEp2QMOS8aokSZ//////UmcGJDDhv///eTRELMyxYmWxiJPBtM/jLTDCza+txWSEw/JJDBJRqGtprSgXQs0ZuYIYH/+7Jk8IcFr2VTo0dnoIXLGv5hhnYUEZVQjAk+gdcva/mDCniQFSI6b8XM5ezsHJl0odOnrL4abHWlJysDkTJaS21CjpoWcHknjmnkxo/nHM5+28qtjP3z9BWqLVJFi/+0pHK9dH8skbvSZ5/LlFuVbgeLO/ls7LSBiX72qq0rdUVzCtS2pR6YIecTcBau0E/9A3/0FZMAAAAiCRXUXRyc8PtQFCApewOCMDsApzJmpIBg/c8LA7oxVTU2YAroijnJw3lgLyKNPDRDUoNmFqUojzChg2FOT58HpSFaQ9QDjMmVBHIcSe0oJ4Y9m943uEVdqy0JkxFVSheQGaK1tznSAKA7LMTPTXBNMIwP1/7Z5n//iDP/8+/9jc///7gynOcng/N///5SAOEHBtgOFERUJSLxI4iSBSyJxpUExghKQ2iw9p5lkiZOEQVLiBCAABAHKo0yAM5+QUG5XgmhiM6uuy7rsuTUSt2+SYwCY+iyo46Ct5hRO1xkakHBlhC/IzB1+QOUNAY7Ahil64IwsNIxITG2oFsRHEld4DdSze5zbmoo2vf2pYmoefzi8K/TUkhfw9pp5gj7U8AGEMAUMIQMqIQxrxJMSTlY0YwCj4ChxMQHgwjAHKmmSUGSIhUKJcEJoscR+loXCPfZjkKdF/WkNAWzLI0/LoMGrwiLK6j0GN81NQJe8tf15FKocZMP6UQwGAgkE4cR3Sl11ehPabkwkoaGN3yWfo2kIpFcyGBY6IXozjbCGQrl6ezcM//OWtn/RbD/97v///8uj3hpDe//z3Eg+tMwzkF4DYqF750elM7FAtmMzFSKcTMhHFE+KXB5Y+3/+7Jk7wcFqWNSwy80Ym3Lau48w4YXwY9JDTE6Sd4hq/mEjjBqDgtueMZgJFR9biF7Omhvs9aMbRRQeYY6PTGUrqORhBUZcaknJsIXYebIpKo8MKeL0boLEb/Nv3K4+nTQCsE2zYCEbb7UgQCip+m+VR79iTUc1h8SCaBoIUy16axIEP1I2D5WoiPgjBCSUsiB4Lnir2sjzsDyZ9PlgqqYQgAADw5MMIwREm04wCjNMQcToBgQUBBSRdRXYVUONsKhA4ZMIUCEYE7Fer+k7vsBiK+JTG2W0tBEKJ3qSd7xoDotJEo9AGEAlF02fHE6ZNYSypL6o6eZoVFCuJxKbHkKNtWcnx6THlC54rrWnYfZjvm6bnbaKSz/7W3MY5pNX7WSz////da//3//7nOxXdWtkWJCW34vujsHUcLMqF1S6KogaIU4s3bGxCqIAIGIAAAJjOHXUKMZxTJagellWd2OZWLDYE5WmuC36hjetnVm7A+XXqOdpfkThgyuPq9AYL+hced9upyvmBKslx5YN4/MgcJsQhxaU9xe0CSIMNkVUafDH8DbZrGF8cFNVwV6yNioHVOPcWE9zpN9f2v+/MwRFOw/sYr46f9S7GWERf1AFpEhAAQFqPYKBGi1EguQoSW7iCMzsEDKMxEPRmJCJhjqKqgIEisRcC429FIFpcqSMCj42XNeeO2feK4RFkKWoljbaWhLcP7+xVAs8e2ocuNp/fPXI3nz768cny09Xr7RmjCzsvFbBZv/acspSiQixqDCf/m9XXkI53i7Ijh4ie/RxMxg8HRJ4yZAFZh4qLlUFFo0d6UQAAABGAR9LGmQFtbW6Fv/+7Jk6gYFSWNTIyw2MIdq+r9hiIoSZY1RzLC1QaYlq3D0DjBsU2TrWlMLGPcSdlFMVuFKQNYYnUOjBYUURAUPTU7sLDaLrSxWmPGqotF/jaDw9EQraWhTFMBOFBNMr1CMKZFz2i7UTeSSoZPdQxGNVd5l0j/+ieyhrAXR9NUyEgAAACyJ8Eby/oQeooizEoIdNlqvQUAtKDGWLWAxoFIAaAQozRy56GnolDk0mbbU0RgXtClcQQFl+F1wqmovRrCweHRfMHCIwtJ5d0czk6ddaXRFqJg2XL0MnOLB21Omh5UWn0TlrtHex3WyPC+fju7xGp4hBImip9z4xud423+xL5+3787eU5LQW//a+yt3vavWczU3NoH5SEGvuYQTI6zuRUPdACAAAAmCAoegu3ZtQcETC3YEIBUGX6HgFBEiDBECAzSdALADJQERZn7L5Wp9+nyuxFfzpwO7bXWeISFjyhlVJx039iJSIw4D2Wx/YLioaBYcHxWTn70unq1CK9V63WWC08Pl9beJKwtEozM3nbvXxll6cAkUz9Zyjs0gLqlnpYfm4RJUYX2PyIbE6bf3/dNs7wDaBHOzoK7zmeoS8pMncRaAPzzoNndwgmjniSKh983zAIBav20fJkCsUvFEFl1pIqlDG5usu5wmLMYWGl7UCZkpnTonHBT5NSFW461kZMZGUEbRxNMisq9dZj7No1fvraOdXp/6XxDYWMOsuHfVY50Bs2BIRmwT/MzF15THWD9hEUQUnnUTUVwvn0qfo0v/D4X3Rc3hJytC1DqXeGc3+6skVCACEAkttw6Aw0gWAEYl0usXTuIEnMUdeZCdIVX/+7JE+oAFKmLTWyw1wq8sWltlhsZQNXFbjDBxiiqxq32WIhDrkgZlGKMMLyJzBfDSlIkt0j8BdYK5IBA5IstxtNzjWFnkxDnOs4ak7QlWQIooYh5UtjlWnERbl2LgYownS/WDhIbjoWTYh46V6bH/RFvsbvfz8ZdfUTd/zXH8dR0nKQogRj5ks0pL53uK/HpoAAAAAIpF5YGVPkaRKOhFkKsujA0CCwulEghjgxC6NKONqeQTAuaUVi+U7efNgMbT/ruTAtlNGSPKl+WuYCiQ7TtOTH4eicthiGppOqIsWfpSl3mJOS4jdaj8P9I7dWZgWN1n2eeEOjOSxjEGfbwlekYGBFk4PJIIU/T5dc5TDk2dQoSJCsv1ryFdHU1m8fjdhE/8eB0+KXMGQL/nFk0EdvGx5AiSZXJDUgPnjoSOIp+OcIFVlYYiEAIAEmRna+CWDGm8BGQE5OcMmhMYY3NLRRZpKZcOAwLMGRtbrTsRmFVpFH7MFUszJpuJXGcwOXegWNw5KX8w4//c8c85jdRZFjxaIKe9QVCeni7JhKSMS8Hw3u1QLT1l5tw17SyUTFphKJvflCqgyOEJgpGmPezwrZcLjf8P97VdtWxWkUjeewVQuaYCflLGSIhxhbJNFfiLqKRaVkDajIalZaohjgsObBKRe0EPlzgfGkMwCBNe4Evh7OXuK2CUuS/7lVmcrrjtE+0ald6MyStSYrh4NxAD9GDjJYw6Oo0GzevFVPDCrbaUnpzDG/jphFVpav91GicjmSjybKSnGohg0YceWvalvSOx///nXNJGbXs//GyETCdSB040doYFmHXG/Hyxj0kxEmD/+7Jk8YYFpGLRQ0k/kpJMCp5gw9QTJY9NbLD4ybewbHzxiyBCCKCWnLKuCdOivOwfQEISuoUlHV3SJaVI2H3O6i1RJpql9aA2+amI+7q3x6T1r6eTQ3Z0C2v5EZkumpGfOjms5DItMzLcgSsU2rvwaMl+hhBAryvnt3hrzEnnz/+he2sTNyvdaJOa5QrodpiqQAAYVJUA4UCMgOAx87W0N09VKWLhQak1IhhFAWIAjZl8q5AfZkRa+W9ZVj5YFeitIz3T6MFCMBfjv20yqVerlRMJrzypByb16KhLPFy4KveNJPFn7IGCKIg5J+keHq0iZTLWkdLpc2ILxX8JY5AAFNO4c3LPQ9tv9QV2/aM1+zkCePNNsY8I7EKi0d/tjGY1OGM0t8ReGfHbx/2NqOlSWEgAAAAABMtUigl0MkFFijQ5UFypN1R1EdHlKKRMOB1Fgw5QqKjjVcVEHEwS3frI5mEp2dGqZcjpRb1/Mk4LRWz20NbtGamuK5wFh5uGzwsSw6SGl6QI7p8K/pa2vT/HK235eVj/7qJr53xF/mtngDXj5n64zv+0P278+GbXbb7xmfEHav/rmVApKDQMLRfBByi7K0VuDs9HU96jGTGEEArHa9IYiLBLsdVbCWrdU0W6NiHglTtoAQUlRPRY7bI1S6cWk/EIqUDZHZbiteioI846yV70Ehd2AJOU+OvXCaNx6IR2WS1xPO3caHo/ZWp6OIsISihYq9RSUxBiJeJE6g3EVW4EP87GbHa3OgsrIMRnSz1VeX4bU/4jydhe7kHE+da6efDMfTn8rP2f6YWFGqMm0zT6fSV+f5/fe6taEJUAAID/+7JE8gYFAmPSow80Upysun5h5nwULZVLbLDYQkmyqv2EmhgACk1AoFu4NQ0xO1A0mLROkpiqikWsh/mnqfjie7Y1QxR/gVQoCBWcqKC6EnMM0JgaTc7KmdZvoDHlGWqECclYaixZhfkdRnF9NLCrK3m/vlZbVuRT9C7w1nyt1qKLM/3a0n+15Ht9Lxmj+kCsz4Qua15l/2KzKz1/2a5AziCLWKMwEmXDaXs/o/vXdW3UOgAAACWRJBiIapbanZjWj8iWjOqmpIVA6gVQlS6oWiKID2hC1gUfGuQ0xl9IF3G5lU7WX0zcnrkOszmxD84/F+Zs54wGvGLvzDkNqFBuYBGyaFjKJjeS4hMHTyis4vs5VmYGLWlCcWwbsXx1bZ6lf+2MwftP+0H6tUxw2qQ3M+KJBOXg2aM4VYTjm4KH68KhSDfAjgwDgiNwZXNptZiNDBiUblZWLCJqDIS/yunVg8IYnC4CsCd8Tk0pdZuTZigjzRhGYOCQDGapzGVUIZHpggBlbproRnIys1ir1olpA7iQqHnQhttXGI7rfpXZq+7vym7f0R7DRyRwijEZ1yFKT9GOEnHqou2RAco0SFZAMTgYgacIwYwACARUMA8kQZLUjwGFy8wQ0S3AheWbMsZjTZcaKB6jLKhgizJYgXBFB0m0mmdtyb0t4IRBfkHBgk0ZLZOlKF52HIvvOriUH6zPzkExEMAGzHSpd0SGwOI6y4DuUJZF5NpHQF5ELKTN2IyNSkerpncRkyQhH1ARXRSHSN7nIhnOaJNQClpIPNp0T55WYNgiDyYvnkatNzeIp5dw+bX/SM+i7WoukJvcFf/eN7b/+7Jk4QYE2mLTWwwWsm+LOw9hJYBZUY1Cjb04gc0s7HmGDWSOTHYG4IiRX/+7IE35TeHchnSH8iIySAlWl+vdlSuSytjKmwsewukaMsEJBq4wwdnwVIZaPSP58XVvf6GAUk3wIGcvgSjf7+uWSl/4YBBu0QFp7QOjADAARJMsR+wnAzZzzCR5wj6Fc9O9Z4N7/y4MTMB+FnjtQAKxxaJMhuiEfGZujg3g1oVcHIAAAAASAhgZMSJCDdhkCqxpSN4wAb9S0xIIWFF8EHUIzJpzQRR6SUG2rxpja2mHolIBYjDlNDUDQXALaUrdlH1DXNaYxSBobpqd+MozDDdHISRZmcJxHAMbaWE7aC5Ym8tl144WTEYmlkP1DZeKqx/83DitoaVLlCbmR7GFSixznU6I91HK8rF1b/1bZ9G95HV0RRUcPjzso4W/UUEbgIBhVhguoTRP9qAAxBau7TrubImWAQJUEhnSUXZoyR8KtBI4Zjq0BIcDP0PeiSBPehSD3e2cZF/s0Pykb/+4hUDuwu5Ga1HZDFRuvVxnGc1HMjh3DfKedFRroCar7R6mJU7/ed1Krt7HMJnFnnaO5XmHydgAASPRCTVTTdoEog5gLFUKV/vQkABzJtA5hjYwZHCxtwx8wp0zhjxEMF7UBS24aa4CTUXWOupgcqam+pcGhY0lzE0AAQVX61xFSGZE5dDBbQC4DW0zmHvwpfDTitli8xlRy19bElQnHSGjKxpY9Mh1YcHMtmBSSwGbwOdazvplOfM+cR179ajVLvib/UOqEiajpE19jnq3/mtnPQXFvIIPxWEooH1YTmRqe1P84Ry5g0HB9kH/+7Jk5AYFQWLS40wuoGsLSsxgwoYXHY9DDTD8gfSwK32GIRhyiAgWKIhzIAACAWpJd+tFJwMS6Al1rLjo8lIiB0eDqMm7DIhkZyDnzjPGCC1hcqeoOH//fkTbRXSJHxXY0+RljS71YbJc73c3HPvu79nkHilZGswJh7v/RaOlzJLTIr8j8iMdqJJga0GfPcII6UZcDR97WTY0XFHyVk2P//YadwyqShAAACChCEu6XFUFShDiVNdeQwBluwcIiRyZaBAEUMiLDKIgw0+AVcGOqwKZcVXCoMnQ0ovu/LEnvFDteTliUFxeUO62CJBQFkeOvpkTjK1SlYUzpQ4GFDXmMoUOeySKxJkcwnI/0vkbW5HGoFjUbkc9EXbU6lkMShxptYkfykXMqJymmyu9APYnhxuPH+TFMjCYLnI3iOPPRGzmkD//+UGhvj5hGIRsTDEs4eEZ7lC890btsIguLiURBNjqmDwtctEACAAAJsMoPhLWGIAaBel2Jafp0p0919mbCFoQIzCq0KOy9rMnAFyhsuPLozgTmdIM6q1dYeeWpy7/SfWSyTyBF3ODshoasT4NPB7tTT8OwsS/P2HQ0/P27eGXUUyN2/4WOJHahQLSW4eFTSy/kajtt+YKATAEFSFzK3vAQqCyheJ4RABHhEGAGEukSCDhDEExmTC09kwoBcVils5AjXYJn4VJGxX3Bq5PZLY6yKJxl2GlWpM9sM255irlUtOFZiOZoFQdEyyyKLGph9STLIyss0kkW3tondZGbeYWtBS//xLcpHK9BPoRsHh///zD+5TKJdWwJ6DqhTH58wpHAR+iqAdryrqBKkvTfRr/+7Jk5oYF/2PQI3hUcHNJKpw9I4oSEY1JbKRagbIrbLmDDhzSGRlvX9kSPrp5wTH3psMBiOFyhbSBe6TWkEPWaXWIJ7dmBNZl/o1KC56lDSQmIhW9htNuJDDC+SiOVKhqnz6g+XiQ0uX5EZCd/H8pQ2gEue9Ip0EdDxI5QoXu3+Vxpiz9kpTVjAIAABihyaONjxK9iaZiJeLCgFAhGBjIgIQlbwk1GLEooACkkYIUGgzRsYgRDRIJjwuIApfTOB0HjRhoDAjiNqOhMhqLRvP8NATYkqmVqSa5BClzwp7CQotxYheJ+kKIi7wblwDhLNm2CqIZTIIToJL0OSyP6IGrw4rVxdUtHBsVkxywJ8BxCh5zBUE4cL/6E/YgXEAzNNPFDRMAstmvHG//9GTlBHFA6eOmCto8cSlDBoQJoLuIp5hAdYdNQg0sp4+20iRQAACAEik6KAZanGrPPqQam286zEUEDAlg+fMQfIIqab9HHVQRdwiuNBYziwsDSUanoYs0kz55w5TkpT5PvpDLJx7vbjpvoflMmnNT6K5zqfJ71FDblq5uYbHzNjNrpZVlmau/plS26tZW0q9u7r9q0c65HiLA0d10X5ORitMgdAXJMIwBIBZV9Ti+NcJPcCisgFUUFx4sHRiqJv4mhkeboIQW6YIZhDDxEfiDhMOiiE+AUURgQoMT3W9EZQs99UkUQFrM3Xg+ZMEcQEl7adIdCgWYTIOxXk5MJtbJFOoUyfjE6UzZElZUQ/c52w7J+yva5Xc76k+muWlEuyXf5hif3R5zlRs047p///zG6A/HGxoQajtPHjyhcGEauPlSjsPsOTx+UIv/+7Jk9YcGFWPPo2w+oIBL2s9hiFYVJYtCjLz4yh4tKfmEoiGKmQN1EAAAABIEoYSpSVJXIDUwheahzCl0NNWU8C3JAXLVtlcNw2SMlRwVy/RC4PgcKxWZBiApGhM0iLs0HeshMzqaJYyYmjy3SG1MixVNBzue+bJsDzS3up3PHK0ng/VjKaMdN88eKnGs+iFU0v1epJFRdkc1//EDEt12SflVyLKqjzcXvpA+RSwqAAAgiZeIxmnYmrKYQZfEILADBVZRXAoKN4BHRsNQsWtAr4tGBgACeng2rxxGTo3WHEjxCSy5rDiUEIWbHHcbWRO9Knlcp/GKM5gV1ULH5mHbcjeIEkZgFkwqbO25PbZeYMCtAaFWKvuhHFWTZmc0ie8XF1JVogcd//qKt////1FfsgoiCJhSoSHQsSK8TSNiwxB0WRmjKOcQbtDoABAAqEnZyEs8ijYkCJ+2MCiZZk8AfHkFkK12q7uYjnZmg+1QxUVCuJZhY+O3oUd39wIEgUG5QjD0pRn4V6ExCEaKVPPXXKZknzBmuNVyax0/I7WMHcOZSBHkBxMdO0VzihzKpMgGiZcNZ0tltGCA6VMUuy4ah5oTAraBHNUqBRgykBADBHEcYxkMLDZZ0zCqAiHUwHlIq3e3Bqyl3xCiM8JrzgIj9epJ5Whr8DONcQ3LbJ/rnXZLljvKrSzx9a7xYIpHkkxAAjRw0LqrnxEJDJ0mA2EzRwhEjIJBtyZNBGikSAWlrICA/LjWoxFQpLf/6/////Ki7oQihR4VocLxLB4JQxNFo4Xj55UTjgTnjRUIDrTR50jo843GBuzSBsYAAACsIF+aodn/+7Jk4wYk3mNRoykuom6IGps9g4YV9ZdDDKT6ghiqajjxm1kiscYSAAaD+D8QRNoQZAipUArEqwwXObGHbRuDg+5WAnKIQtqUyFwqubS+iyLG+22bo86mDDyCFskEskbHKuCQSn0+/sRmwCXGQweRB4YRSW+ny1LQiCGlFm07Yvxvw4//yxmcoEzvT1LRXPTclnbSj8bB+f9tj/wZFnymQAAJIjKQCJZUnQY6YsY+DRH4AIYKef5OsgBG2g4I1s14iIw5+xAiTAUbO1esPZC4iVy8UcB4RrDZ3Law97GIZUYXrDCwKwsExhWG48cTV44MNZAOdOBsZBRQuFYk5iQCkLxQRkYpQAZFyFAHjaMqpNdCgJ0HedYpJENR46pt////////R+UGImQauPDYk5phvGk9HNEZ0FBAgMBcqYqjUmrKziSPjtUywpgCAE2205bCDhwEV2wI7r6nW/RCSmeVr6xXaTrKB2GKEdm8WQ3jSmagcCBZ6QMuLjXUOGLbA2dDCtKNYw+Hhik2BfZxVV3JZk94K9//G3mepvvtHnP8KxT9p/3MKqLrt39u3tte2bvLPu9wImlK3z0b+fSas9FZ2ovOVaGGFfkIaEIJCihF8aACAIcYiNDX4QOaOvNKlVZaY8WPghMcXJEhmSAw9MEqGrgcIg1syfi4jDgEfn6chc8gUqBgRPFL4w4ZsCZaTKsTwMGSEZe09Ix518pgJCMmWgly+PB4LCo+JJfLjNkg8iWWDpkPEA9oOAfFYuvxoZ8dpBLZPDoqRqYWZTuBKW////////8oY3NuVMFY2B4PlxQIpw0ECCMwKkJR2qw6qHnCWLD/+7Jk6ocFQWVRIyk+oIOrmt9hhmQWTZdBDTD6gdQtazD8IcBYWUXyI2GoXKPY7HBCEGp5dv2FffFquzkukh3GGnT2QRlI4+xFBPB8VfD/I7dSxHEXBw8VHFWecKUeWRd9Jwo7s5v5fH9WywznxNQR35GOXxlTKXyjzA8hXOPTe/j5LHRw/y2vKcv8mW8IIryN6Gpbjol9I+bRviuRl1WUsvUqM0AAAE42ZIls1UOMmCAA5zGWlxy97IERJ0wY4cIFQUZUSFxBtb5nB4WBpXucnQiatVFGK0zWk/mPrqWLAjeLFfAtM2rI4dh0GhRaJoAD4GxCGJaEMD9SkMWDsImiokVGKJtYyweFy674D9LFAwdrhQaNJjlXma9aWKAZv////////Qot8aLiQ8eKDzDhSLiAiH2KOufzbCziI5SGQJiAeRFDLCIICIFq3dxh1r8rEnvRLGaLyqMtUtddtWVigWhL1pcHvJ03iBJ753LTDANNNyMqXc0Ozj9VdtXAubOuqcYM1rDTObAZRLNyQKS413MvInNHsR2h1hJqH1p/7q7/5RsqOC3Bl+x5ApRS7NL2wAYb45Q/K3HZd2OOCx8WU1UIgDABCFYVEgeNrDmwHg5S9kOlxEBaCrY1LgMFMARL+mqKmitmJNkwAzwhBhe6DDFqRSh+HafosB5AxearuUqq8TFUrW7RmlrM3eOLugyFrF2OPrEYHXJK4tIo1GJdhZlEuE0jqci6kU0qxQ0Vc6UV70oJHrsk9luDf//////1ydGKjjlulhdCMDHEhIYQcFHAZ0EDx6DR7JxFRRjHF2OJLbpMroAEYJjbkqDI3luJ4Jj/+7Bk6AYFBWRRQ0wuMn2rmr5hI4wUNY9FrSS8ShQxq72DIihPMEemzPr4istfl43KcCDHuceW6JETwk4w8N0CTpJhHwgK2nzs2WXveTzwgFRaCLjtKh5t81eJajrhYV1bz6inGOOrQUt2tjVja/9UYm5F3eJS+5DocYv/zcBjtrdHbhYVnrmpjibkUIZEF/kcWOrmbLv0qx9IRAAAAAACgOIAQAcCQ7I8mZEGWBI7rbUYLAVUjAXKAQdR0yQAyd404YKJwUELvkxV/HwasnI6MOt3UzeqVRVYd25epXGGZpgpqph2mdQ298oiEEutNrpj74QPEqC1uWTN+NyXcpmspRbjWFa/N1JbIafIoI5gGMKkH5MSjRskgXO///////ok0f/SiwgetenFfJqSogk/HyOomnrS7RJF6QgTYK71CGX2aBC3FiSKmR5VgAiFpEkegY9k+a5YYxqi8UyEpUTQSMAmjijTTulWHL9PfClImiBj2t6EOkHRFM4FgPYzLQ0BGeqMYgat2NcssDcZfiwRjQs59g5z+CDMsChwoFEmROGKVmMzO9fTN3dfn+WXxwgkW7WJ/yJKF+OjTGEBATFK7Gk1hkogo2QjoT2RIC0MWeqHCoCuAdAbK5x5hIQ8vABdoWJWEYHxzWFTL6tNdFULJ1L5dXbVrkOcT0d1ebpvFL18ve5zjzcpvV3/lN6JSyITvKPKl1hc1ZkEvn8uXakoqWCajJYuHi4VO4rFuXNEco///////9jqMj30jcT7CLkEvSBuFKawmcPTpRZ1wUKHx9e+jNyFAzBSb0TMhGCAIGHR8yyIAAQLiaaTzRcDXAmgof/7smTshgV2ZFFrR0+icmsK/jzDaVTplUeMnT6CLLBrfYYZOczAA4Gy4QW0FDYBywejiflUMVqnpzFCFHf6NQPKZdKX3vfYwGYTIAG4PK5zsYWZdHjnC/n5l3OdsMkwy5vHMNIsyMP/updi112e9UnzFfnFmNndPLgzRbJR/CEKshwIIZzsEPAPRTj98t9gu/8aNc8LP//+7d7qbIQrJZlQQAAAgGhB1qOAVUMoUF9DqEeYYYBQiBQNCpCxE7zfHJBGvICVDG9f5m7OHhgR8HBbtPuy3Je8Ox1/J6IqmYo4DltRgR7qNljizrpvjPy/Kkn43nhK4JqS+elOVmUTE/SSmSVOX5VV7uqCCoKcRkExFxFsUEgUC///////7JuvfeRiaRkNE3/MwJMRa0xFUiaZERMh7TxDUopciRPZwltyeXZSWsLTuykSkhDjhRc8YuR8IcX8OX2M92/ZHGzcjGofgF1YMVXdaQdI0GaZ5u629nuTaI6hf6Czy8V/0YExnze+P/3i0ZOG+VdGGdrz9v+BjvT2Y9v5ohqR+Ky4Zr5tmQIln7P5t/xiXaM5Mbh1BaH0KS2GZBSHQhgJMg5In2CQyfxh3acphAbXkTjVAiAYkcJF0uAQ8NtCAAVNU1w4RA1AWjwJKXnZRBatMBKKLvi7SVwSuFPWOAaBrEtSWgOJssgFc7T2W5w8txkkVZvKX7h+mZZclk7S0ecps57tuHPvRKJXTzWpecTYJ3GxEgJkDJUXOeJbo3//////8ojp//IUIlQCJuDe9cgGSxf7aFyMvC6NmtVmsiRnF+LHifrLZ42cM2TNJZcorugEyytK5JDvQ//7smTqBwUtZVJbJU+gc4v6/zzDjlXpl0KNHT6Bz65r+MeMtEfDxmd5BsE6RUdtkvRnilPGaGlOMJ0MGEIHDbngQsM4gLR+jkuG6bd//h1TEDYsVgjF1FuJGOHBCHJ38qEkInIyQd0CofhoT3gr0wrqXdqYQ834RdQGJb/8ofZ0qOEF1SGD+w43csSaFWEAAABUYGEoAwQABIUyrwOFo+MLMARBKpB1TFPsHBTTzw5gZxcIBQ9gKGAGBiDGAfovlKgXE1OSTURDz0PEtoUyPweg2wS6uGMLkQUWcUItSGEmVpJCLRM5+JFGl8LieB3nhddvXCylohytQg6WZuVDWy0am2ygVKgkrZRPYM7Oyf/oY36n5jf/jhbHGKFn+o1QmLgqMPNKlQjEwux1hIuOFXLTj5yF1EKmjppw1LHCokNCJQllcpmAY1m1LeqnPQ8csDADeSMrNJCZWBPoexNj9Ht8VSiw6qk4kSWzJCk5CYzkOKRKeSJ2+OtsmszEUj9TXJMxMGzbOYnFsSKHoppmRJK6fWQGDRFE1jh3uKKGFjA0w72BQwhjPA3Ol5i14bIEM8/vVyvkPgGpNeGX//rBXIGikAEQitbATYkQpiaHIGabEjuloBEhpAvEhsh6mkPEg4kvAX+VnT0TqQOlmnJ84qRwTCdXDE2qBYSCqePlADcfJ1DitLaZZ7ORvoQQ061tAq0/VctqdcxmPddsteyP4TuBBh3nbIsPD1unleoW8f0s1xnv/6Eb9U0b/8w7HjkR/4Ow8PgnGiyijeJsAIDh0GLFHMJTsBBRylHDwUqCRgiJ06W0gAQAEfE6gD/IEIyLVZsByv/7smTzBgWvZFBDTzxyfMw63DzDnRQhjUWMvLHKNawpsPYaOEpRYpaejCNG6kBYDMHAXBUexWPI6spjwUPxtSvMBuwfL2l8XV6B5s+Qj6lXmCVC4KSIe3sQi7DSrirWG486st0upfQKR483OW+qVp3K5nTLjE5M+zc523Pl/N5jYViS61e/zWtk54a8VcRRnuLxL/QXrAAdzyId4iKyzlRCAACAApoOMzImuhDQVQXSSQkTGraHyCBf8sJbqJjBnyQ8IswzHoenr1lkO4xYeJRGHo7Fq9BhLixDLrOtkbXLk26w/6t+0poQOqxIxcZH1De8C7FUbkdr4cniEPCcVpzCJihlXHDONToaOgUO2+EmUW5TJjru3vjNkyqmbeP+Fri6h61ZkislSnDo4ejfAztD8ZwtfAwZUomABAABZy8C+R4Vl10kKHjliBiSlqfiMygi4pUIY0A65GeX3TgIIFhxJRCh5UFxOQKlD8BBcynI11Tb1otEZBaK30cQk6aJyNcqyX+QvGYMq/ejNSVkktG+Qtn8SjpHjIBOfJuHEFCu2osmUw1zyJC6F4B0pES/9xXFaoHOMYinsw4oKo7t8Beh84pfAQIlFEQAACSyWtokl9KdASvoslA6808Vbx4qazwiBYwIzsMUhYqNMDuNCXEd7Np1rKZeqXQNWhtYcsKjkk2ANB0TIkkCREPMzXJw8yXJqfRMRoljzB5Gj5AaZ8TtgQWueg+a95eP/mVnOaalGtzvVVlSgW7Rs7m+Yz99ztPzzX/3tiH7/7mxqUxXdxlJ3CL40BL6lNVzf/+dCqYAAABJDvJCZEDRUhG1wOFJ0718TP/7skTqAiTDY9LjDEVAjyx6bGUjjhLdjUmMJNaCVjGpMYSXIMsZU0dXLdxyAEkhaxNxHji0fd2amt0kNvRE4rD7iMibSTOdS9vxa8RCFMGpMnFm2Eg+h1cUkBKdZOromUD5ITxokXUXk5dzC2wjC1rL7l+ow2TNQmsr4zy6y4z5FUkjGZ2ud9L1Fp5i9uKsl6mV44qlqQikHEFlagFuLK5oj8SIkWAAAQcPDk15dEAmUfAK2qdb5a0CjhIQOsGgixRMAOhGUBmbtALIZgGo+zBp7ev4/SdPGiPMzFxkw23bREh+EqF+cZ07k420y7q5opVH9QvAR5m2Ui7ONVuJ2IY6fNK6eJHR+JaUbVXjWckKDFyNEtw44iQpm2GN3va0TRJFCoUTYQ6GUuo3tka0Yx8c//8yiu////pnv/U/6RThau0m2otpZX/21JsMTZ9meREonErSi4E8tv/67B+pe5dABFW2aYPTUcZYyRRwhi0iD7QEfxQNdEFt/L6SkljzLr64c5Bm8tVHXpJkxePhS00cRd0bcVFzbN9rde2WGrW1lChqwuyt9sxBCut1KI93CMdnKr9e5tl2tmvOpEVruLGIzhzrQubBNftL+qEajyHpbG07l9oAAFVLL4iEIVAg9NA06byIYFKLiFBF3lB1cEQ00h4Q4MRkWpOTtHFcZbVa125D0FTcDROhjdO1HPsroLdRCQRgu2SKkCECpIV2pEVIZoULV2oq4sfZm+nrbbb0l027ZvNv/hJnI7FGKUcMKWdnkX/6Mf/q/j6mM4kHOQ/QR5yCacVKGDGGQMdYJTbzCsAGoLTjsxOC2AnAW0ALQJkF4P/7smTngAXIY8/DT04gdWsa3mWCfxFxd02MJFjB4y4rfPGXYYynT9HoDAFrVNar0JL+mInLYypDsj23pnzJE4HGLvONzNk88PdLsOxWt5jz+vjloFARtHTIYTlCMUDqFISfT/y7TQ0u1YUgF4N2pAwFSFV0Pvmhvzf2dfVV6iYRDhcRiAuwJFWwAAAAS4Lpp9iMK6o6OSFfW0u/IsqMj2ghAws4vshEMROOIQiYepKFyRpsNqO0kSjjJGAsaUb6/S11anYizqVYlOmxug0LJbJrgMBwRp/Rn/sHJLpZCWnsbiI+YTt0QSkhJnkJ+lfvWl9aQFcT1KMSEbxVIDCGKmCfsMQLu8zzDiHKLm42QMjMESdrkErd5OkTIfYNCN/btuBYLyCoAAAAAEtCHDpNjwiqhgQF1VO5UomjMWREaKghWkCKlYhWiBgx6NKQqOO/roOUzOlfGlmmpr4rL8eNngyQzt+nEgarCIAlFAwOyetEQiicflUveY6cK2oIS0JNComJiZfGt8+MVTrS9Cbc9ujUNzlUxV1+ypJLqKlybYeY4iJjhtWeKeYj8JQin+y4v6dLCyPl3csqW5GuXw1LC40IhxYrVVS5Zzkmqf5CUSkCTSFYQLFb2hKqxKTLVNEBLcGUIEXmVM1R5HfC4QAyAWAQ2xGq9rxN45fFcyLLXDTosCmeMFJGjUF9NHliKVZYijgxJqmCUs0Q+xmrjJLg8TwPMl6YfKdFSjM7fetOt3URfkPI3hIXVq2V04l9E6O3p7DgRXNgVtL58kX156WL9+rve55abowXJIBRZtrDIbL1AV5hBDrmMBSWZwKLRydohQEAUv/7skT1hmTfXtDDTB4wqOvaC2WIxhFFeUmMPREKT68opYSbEafcvxLGkS+goE6o/ulm6dsy5p+BZBBrgJKtrWiFipIGDBCZHhlA8ICBoauLKqM+JWHKxkuG2+jJDKcGXZeYvUaNU/jcaV7niH1Dbhcbs197Q52b7y7pu14U8c2f7T27I8shvAyi3/QW3vcOreXkpTjk7PcDKb4QVQCQAAAIKA5qChDeI8EjgagLSLqr5Ao5MwwhAxZYWqjJ4cCGGKBCY9gNzDDAXBUNWctROxfs1NpaodEpEunHxkJfkOFFy17sZZSmmvuD5Ez1xVB5kiCU7G4kTDsnATQiBQDhDHwkPm9ozh8zLKIXg0PF3lZMwueMpfWpVbdjc4PEkZYa8S0MBtiLWOGLRSFcwKi9O4qDED0lHPpNi3DlvHFd2qiGVQjWIYBFJ4RBYzl7yiwuiGceYXRAg3AjIX6MbI7b4gCAAUUlLt574NUbDLBzm7aX2jK5y035a9A9yGWapIXXXSIkZZa2tUJyQyqxHQuKc//D8/OW/3ttWg67D8J695C6lFSaU0pTqsg1mW5fNVzdmcGolzUHSyZzjE8Mba9SszPbg1GZUDKB6T/t/fjh2lOAAIJwI52SDCgCFAisgkCVA/w6qX3SHW4u9JxTghQJQEOKWo0iFYDAgAUCXjPgyFwsDDMIvTOtpQ+CeAnk4aasE3JAXwxzia0QcbO2RKKdeCZMlVzJw5tj2cz0Sp6NjLGcY52QWtsX/MytbyTyo3qRqlE6BTj0zHBjAyblJFuotFyOUtJeTkZjGzzIYzT6b5+t2f43/LRZ3zv++cy+T1PO5dolnf/7smTrhgYDX09DTDaieauKfWEijhVljUNsvNGBni2q/YSJ2ELvVEJ6Rr/8xP8osCzpbSu6qQKQIbTaul0MbZy3MOqhC8cDu6wlnaerov8ztlz/hYQT4/iMPkebW6pPaiOIFN62f9N2CsHO5bWuE0VJkz3MS5Ss7vRGRWZC6tECHKOv/rZpS/JlqdbUpv1+9fUGdiFUwsptMMIEGgAAGmCHKExELiJCcKiIeAgEdBEZjam6mKjGgIaqbKD9rMHiN8oFpdp02mo9pHNHS1X40yRs/XYFQrWX/VvCgNghb0oBJYTi1GsOvDUVrwpStVFNJIhij0NmbGk427XKSXwuWRl1n295YclMoeKBaOvEcc4waQirDjiZlgRYfDk8RCREdRQ1oLIUBlsKDxIlNdRHaIbQGSyCHxs5SavO5/7j9//8aWRWe3i1Xnleh98fFuVKRhpGgMRUVxN2/+W76JjsuhGB6AAAAIt7EPmYCHIOgmR/C6lqw4XdSFjvD+ESqxo6smYm+MQqag9BbCMgVJ/+OophoAl5qkFSs83VMhmKQUtA5DtSGFHF3zGMU7UMuqG1T/plazfO1eUYx0AJj+rOemw5MEosAcKd2BWSxBgQwoFgVdQkHoTQSSlAipeocikXjLImPBgXM1skhGgsa4WGcvpyQwZeBJcP0v1eKzxYTLAQz1pEpfAeA04UCnJUuWAdtE0ICmCIiKHs2NJ4H+nkxBI0WEEaL+BQc0qQpUtyeYXc6TaEPdPT4MdFMJtOJzP1hXuYaB4ShoaFbz0RaI2OEgZQH4DIKMhSgVVXkVVOxKplz6AKkxOmxyOZOeUnQQY3d//////7smTshgYsY08jOkvwaut6XD0ihhldjzsNvTiByC0r/YQV/P//XDYoJD9Qz///M/ovAqVwmb5KHGnXHKDX/stc5MJLrn8iWqogAZyw7HJd4yB4qw0FmRfdOhD1urbjglG3Ry1TCoRHqAcgFoQB0OICY3NGb5BAgKmn/1yiX/1kU3siYTh+KIHwuaUI8EO6qLXaOUaHl5DMGuf+Q8yLJ05LIp3b4r7mdIgMHMjpqs5KVdC7kkD0VeNqTCgAAAAAGYrwQiNjwE4ZgMBxpcw0wUTmlgQQgFKHSoYDSSrg+wmiZaSfSwsHq1NigNkQwTB0NPrUXKteGGAz+CfVA36eTs5R2BLbhP+/rzwE+q/XEatUpXlyeCpDkpry3BRowwhIVANRuZKRymnNbXGlEa0zvSc5vLl0a5LiiGMkSfdKHY4pHiIdH3KVVT//7CSkFkD4p+jai4cKHDGoBgsrXlDrEao0BEKZxomKho0AAAAAW/Z4qKA0nqdJoGax7O7p9SJ5pVCyayvXDDEd2004wstBybjByWMrGGa8sE+/3KHeErKRJVuJEdisWSXTaZkS0E/nbUnyKSZMpVv99RIeSEm3KYxC8LKUJEAGSAgWJFisyb9IdB8wIBiQMBUOohOCY7MXCRgDBgaI2wyYfFxkOlVSFvm1L6IsQTKRQId1uDNlTlUBLvQ2yZc11PdpLNV7OkzBjCZD+KgbNAQiCkXgUHJCxcZDcX9QHWOxZRqCMc9jAJ5EbmFPnrs9Fedb9iYV7leok8xJ5T0Lah7am52R4ssv7Btka9fDBWI/jPWdvgKFPYB+ODUSgnOCEwvNN///OqbQ8RfOqP/7smTdBgVxY9BjKS8gXekabD0ClhepjzitvPrB5LGqNPQW6JOVOnFvGx3+gs1ZiWYD41aZxlJAgEpO+iUPdYAokPPBUvUAfBdyQnEcJMlAhI8UE+YYLC2ubhuNB03pua+aUoK9krwO/l2uET/m7kxBiRNVF7uo2Ik9YGUnDLcriFlyU56JXJFG8oOa3yiLSEeyyvXEh1DGIykOl/nTV2kfIJOwqEw7+pOj/mHVBBgAAAAmq0YaI865WIIoKhSI4BAGEGRDqAEYBT6XQhuC7p2WIhPSsdeK4mqtMmJTHXthh1nRVy1h33dp3KLqN411ILBMKOSypxsb9UDSVJvxDURo4tDzt7dl8bb9ajwImZQQECISyKk3dNCHCFtHykVSbTbBakbbutrT/6KYXv0jhUrwhkArmb////fCeWoH9Bv/6hxP+CHR3zXgDVqnI3Jv7a3DyJzZUyFaBVeEoqsQTG9UJn/Lckw0vt5JUmjNPGEf/tZLZBJhLn4NvpByVzgs9npM2dpS3v9RXShDOmX6NhGI29XJlKGhnFrtuzzQFSwp9bYlceiVx45228kIwA0hUIScwMDMOAmUFYeIgIwEpEQWYqXCQ4ODJm58LJIsTmEXBr88Z7BnZD6m6DQUHBgRGtK0FFkosYL+LMQqEJAKBIQWTKqswASAHPCojXk1VfoWOaW8TdGjy5JfZIUwRGKvJDD2oD2VttC5hgk27lSCmW0bT20fvF/1hpQ4TRGZQ5BzQpW8UJXg0WAH/gSSSiNwdIYhZa1LhQ60O5pojh8WIx0hQ0Jgh2GZAcC8YRG////xcNsXEvE5EAqiWTcib/+oND+BgP/7smTjBgTCY0/bKRcgZelrL2EjaRjleTMN5VHCKSro+ZYaIFmlAAAAAAa3jelqWhqUmKUvRI0wB1Yy1DZl1SSNp+q3IzLGlUCw2OkbNHVhBjUnZHJSpaIwHCQNz+N7kM2qigfxMmSUSw8f2JLSNOQ/zGvYeyiLR/beWazqbbcVnznnYfjZwM5ClnU1xtkEtZPE1X8d6ia8Lz9XTjLxmdi0aIp/5Ny5xyhonbiKtS1AAAAAAENWozwCyaHVm5uBBy0ERVS4RGI9o0iQaOxjtCBAitDAWRFQJgUOMRjcJaXHJe1V0HNb1+W0pZE02BFBVzv51hMojzkuE/bDYahiHcLiEDzkVzC1ZyQN6y2k3jSA4OQkhmVjJUS7caU8JxvpHUDPOc4c7KJlITUhCsRm////6dH5aIv/JoRwAinBB25wNACfxATNq6giIGoklN/y+OOID9EhmBWrkdeB14VTW5iYadLqSoN9wXLs0Q96xMABKf8oHpWTCifxQRw3m4b1SYE9Jbr9Yqx5ZZ+biaI1VDB4fjVe/6vs58yM7+UPi5DmVdnVHEgDQPkh+eb6OGQJQcygjACAHvJ95oCfv+SAx58XpFRQkQIBQMcBAteLHkzzYDTjFTSlgVCDD4KNErJir7V3JXey1/lQKLhx5U0209wn8TCBABFF/XZd4vaweAn5c9SmIpHW5y3Otg1DxcWTG0T7fmSQeV6pU/VSWZcLVj89ocPMQVtYt1L9j4/JpJYqpemLSuweT043V/f3h4qUYEW////6F0NoacxHnJqHxer2EGGuRCeqC9VdFF2GYAAAAAD/q9ir0vzXi6LSldh0WDPHPP/7smTiggSxYVBTKRaibYsq/2DDhxVFkzsNMLrCTjLosYeZ4I9GszSAQAqlLFNS0PDttUS6emOwbLCuilJAYjIhrjHUlCoAzQxofd/rAlBbnlqJMo/7RiWamXWuUAtxs8Yf1Re+NLBKOIuJJczfsx/LRW11a3+3M2TvIre27sMieqrJXCOmoZzmSzDzkTJ0I1FZAwv9sMf+D9////M3uDrVAcAAAACNfoVEIGmUsREnC4VRKdBEF2i76lK6gaMYRhQuYwoDRR0JjCgFVrUZLSyuBpFEXjCCbL2M4f9tWKuGsLFXccBvWUMBd15qZvVpPNK5RRRRE65XrpryKIEAZUOrLmmY5A3b0CBzZx6XpiomFJLSy5hhV+kdFcSahv/////vPIPIWQXxpxRgkExYAAgcXAQagd0jRBpiCgqCBosOckaAIAIgQ2mlfiFWKRZ8M66CcywsBC37wAhcQsNrjvuROc7EWEXJiJED5TKWYKrU3fdfoLOWKmoywJzBqEB4zJZjiBbcjSeEq0j5dmuogpKQ2Jr0Rv+uXapf7iolO05/mOequqT3pWb464udJOVXEM7xuyPll3/v/Bki46xBNp8V7HtEzE/AuGHQOwggcxLxYQHDKVIJjMSZuQaCwZCYaBRphNddd4HFTjaQsCp9lDBmgaTBdlTRiDLmQts7K5FzP3DTV2TwU2dKqL16XVJjWh+rbi87hdvzcRqWqs1lnSyWn3Q58OUwgGDQWpCCJxIVR29Zn+IoqGyt/////xvj1FhAQDoQFpzHMlFDCKGj8jDEmS39aCk2RAiRGEwlVWnjAAAsZ/5q2KjUAeiQstC4mdo+r//7smTpCgT4ZdBLKS6gfMy6nz0oaBQVlz6slN7CDLGpsYWiEZRYWHd6JS9Spatfpl77RzZYlsKRTL1AyTY+BxAkS8l5q4dBkjMQDvYw2TUBsOc4TwHpOtSWvmz9fZP5YyLbc1FX8+e/sO0w9sVitWGjkFca/8E/2sM0SO5cnreFie4uYVXHlC1+RPMap/6flF21CYAAAAAYAzGWA5QZ0ItMCo8ChQaMVYUIVzAUSdowACQFLyMhTTFAUwMfAxIYSaiWEYmEtcaWtaHFEQEAlgEfugLfPuW5bmqq2ZLhJ5CFL5KiLQh9Iswus+cBMOeZ/23kpULidQvARjrgdMgBR2LuQlGyVVCQNCQNJTiyWQsVAVPFaeSkREf/bEY8kPvt/////4reQcuJyRUS54/ESJxqgPAgQ4JxscVNUUnRU6jA0NIjyHGjhWEoDsiQAAB1rtwQzXcIDtrMyRhcMKav9DalkiSNcxa0AOCimWDinuMyMVBLA+tLZYF7azjXT4UQhOUGB+MHTSOx3wNVyFqnMD9KmG/qhtlHDK8cVZCFi5I9SeYHd5Ggx36JgaLSvwlwbURx/tdVMU1S8HMjf5MERKH4kIjnpPI/GFTgICGkgRAZBBogJAYRXQ2R/AQMmGvmvgvOBTANKBw0oQnD0gpEATyX8tURLL+DhU0rtcqAVWYLhS5z9vegmfgiDuSmbSvs0r3aac77B5Mt5t2rPOwQi4qAUIAsCYrVOD5k0OGBAq5AUWf0RQUoyUFBwuKFGW0l3kw5yIm3/GzKpUsY//////54kmIGBwuKRScotEYueTHDR4oJzB6yOVOJKOF3cdKDpMiNHP/7smTwhwW3Y87TaT6if+o6O2GIhhWtjzqtJPqB9avp+YSaEVxcu5IlopEAgDdVZU8OVG7jXRThsbUm1KWtMhhuu/8CriSCe+aisfAKZtyvHqBtFakUJNhUavSjTCC7fORm08/M68P8VI8gOepsz62GkG8PVnQ506LJsJw1F9As3banKUg+zCP/MUt5x58///nflrjS7Zq+f/vjPNp+8rLO87N4hRAAAb70YF2c0KZAUVRI4TMMNSCLBFIAeBsFGhQkHFRhMXIlgyqOWVM4HDmRjQquIgoGpfH39js8zxPpBRrzC3xKoFhlgu7ASELXaiAlHJsEAUDjOeut3IefUdxSS0IkddldfnW1/XSLDtbc7UpF8Tp1GZlBqOS3rVlcwtpTt/xFkIooZ//////oPEaiJY0Pmx4wwOZHOBhRGqwwRHBg4kXFpTCsSSKukTmUSQAzAUSSM7AmsC1gYi6Dkcp2OQtwGQ0lBAsiF1t7pZqZ7bNSbrZrIvruUvCzjjthkKPVG8UXSfhsMoVstNt1LwrxicicKeLJA51g6alJ7UooEx2rsVPh9/5dHDHQXll/8nCLTGIzLIURTgxTd2ApIjRygHFQOUDCRQRAjQCQLXIpkgNGAtYwWAC2KcAjWzLh8x4rJhMqCy1aFm76r0SkgNKxbBaGSrFXg87vLBJ8ImtGZOpm9zdIzPROHmhaplSz77tA6OJ43Z7bXOUFRh+7jVl68hcJDtGFHMId/diOu16+ehCVvyHE4kWdhTt5yEb/6vfrbGEFBxBEfOIirQFBwYNwUfFY5RZw6JC4BiSu4wosotQMD4sHAIKCq0sIBqIJiRZnfv/7smTnBgU8Y88rTC6gbKtK3zzDe1XpkzytsLqB2S7rPPGafK1TpwGoXcuWWRXkozpOeDMIaXlLKxUTvmfuUm5jCRzqtaROh6CBjIg4oIHCv2bHMWzgkNTVxCCljtvB3ONVyeuK2fSo+vK20Bqf1Ne3xuvt5pszMx7v1j/bZUefWu2mx2+MH+E8fKxr11lfSggACc72ddSaAIFy4JQiMOEC0hjFEEqwqCRUEAJ+1bi1IQHNEiBVQefTQYMYe5a6H6RRhunXcmEyCKPoia1BtzCFzTRJCgOygpQ4jiJ0urrA4Xy09E5NZ4VIWd46IHHrXkYgJWqSWrFaKEqGlWy7L2FY5qIzJR07bq9ls5/cTk7b3f/88az/1//Xr0gR7K2/IogLTik6CivbhBOb3ZydtMCwvHB0MgYFgTJnkREH9DJEGM/VOhg9AcwAOCRCAkKcicW1qPbDIDAGdOlowF4cphDAwfD0LTp9Rjrxdu62drWl6RayugSOw2jiXARIIEgmQxoIFZfMQ4GKpo4VOMLAyvT6Le07Em5C/m1cuMu4zHztsqnPEN+akVLduZfyCzietjl3qv4xv/kePzMf9wgmUB/86YmMqx7L/sWaMlcoJRJkbKgBAKgE6pemmgWMREQkLiQSJ+LAqkRxZI6SdzJn1kD+VJPpok4+fFDKE07FCt2kozk9PobuI6J2d/lew8dLznfo4cHbR87ZFZ9epvT4E6BDNsbFGrEpTS6SsrezVkt+/Qyf//+K///9PZl+bxijyD1FXyR/Ud7wcKCNALRGNsoVkRRCsJRIHZgWKBtNcg1OAVJAQNINHA1MDpB719RNmoO0sP/7smTxgAXAZU+rT02QggvarzBmxlMpj1OsMRNJ5axrOPYhlFFa/MSIGIebSE8qAqbIJVRp1xJ5msGcltAw+Bl8T1xH/JAjScY9UXVrYyHVjX0eLjWmZ6YfsLq6RJJsD6k2STVEIJxSBtc1//FMNOth1/vTUVfnMvZIw4q0KuEccbFpjnXnGFjh+p4oj10xbnMccjEwsVIwdYmTFZiQ4t4wUWMPBjCBoCA5CCDouYOCgKlMcKAwsIEDqaFrA4NC0eFQRpERlnqtDdXTeVryayNTZX/beKrrYarLTK8EYbkMthnkuhtXkeduHYXfilJfx29UHsvhyKG3LO0OGRQiIVjgqwqqwtUjg9QyfmnFrm8lnuPjWyGPzG9Vr///+9y/////1UNTG2H1TKvLIVjMWQmeG2W12E5PxdBrUUiMOlD5Ksim1RA5k28j0/vcuSIyZVUcA+WLnBSzOhSHudlAN8tH1Fk3mA8DHDeQtXBZ5QGFj7kkZZKAwsJxYsIxceQU+ZG7wVnqm3iAnt8/P7d3qaTKUJWuq1DPXzOth1aK9Jw9qZBEOhgIWK44gyn9zMlVh8uvVW8+fScsr69zTOTaXCia/hJ764GHJB/TOUPQKJis6BzAASEKBBkgWBQMgKQoEGGkaxy8hlowYwciAVApMlyJDiMhgQBCAgFZq4qZ0XZLebqNAiF7Cn4ZA64gAlysiydtlvs+iK82Azlh62yxl4WzwNZqQ1B8odxs7s0kWtymIXZ91n4u16OKU+UMkQfC0MigMKiEx5RwbFxqD3/480RsRv//+nxotfqq2pQIYNEZlddaJlWpJNfSEcmvikE3GkzPkv/7smTyjgYYZE6DeUvidAsaRT0jjFbVizotnT6Jva3psPSN8O7SVWH3iVRYWBRAQAAK5rKEKhdjiFLbIwkQM5DYrixSk/OhCMChcw7V1bj6gZqUZmoseyO7ncf+kt29xMdInJF1zO/uwK9i0KRQqcEzggmQlMMw3FLH/GGolDZ8FFOQvc/2czhWWn/DFP5HSpdQlpsdb9pwK1/YYyEEAAJTJUDsz+QHugQsOgAk0MARlBIqnSNqlIoEvdogdyApXYWGRbUiz2MwawJ5ay7ZOrmoiA+YoNYC5hCXGZxIMDUTT85fJZWOSeZlFvyHVQjRKTE9chEt2OpofsFU11iI/SLamRIJZ/rXVndKUWf/mMa03///m/PT/jc481xoUHy5NyM7QasPDoSjUboAkkNBdHSh4ZDAnUfEwinDc0EnANAAARq7SocHSKJzWDGC0vDjWLNo0JzEJVigzgcYbcNnIW0bR38DTDpG+i/afTJQ4G4JNGtqcJaM4XK9KBwIZBidBQNkUyymsQG0R8JuDDA2mWwQcok+OTWXyb6oMIZgKwlb6VGH9lpEHLUAlJfy/85mXoP/4sIAAnMTRvReagDAQcFl4wIIHissDBbwWDAARmSCI0oyhEQzn83BEdQU5tjARWSFXi+4Z+KiMjnhcTqR5Q5scae5uaymCKAxiNPurRI7z+OhDT7QQ7brPS+A/PMzYiDwSVhIWEAN46CcVjsD0XlkEMTiEKmj6ScmkIVDcOwdxUUvfnDc//qzT7/gezfuv9jPr///+D3/w1SuH82061jeJrqneX6iBQVGJ+UHoLWtyibaShq9g8pGaqoIJiRA0Frstf/7sGTrgAUIY9FTLD1QdkvKST2Dbhb1jTqt4WvB7CypcPYWOCOgLlqMmNOugqCvMiZVA1SEGWhSGiIWmGN+zjrFScvOkqagdHzS+82vzuOs7WG8X9BivWCQosuZSKpY9lTA30X79V2Wo1NaMvZNt7hovUULO5BhGGDn+g+XRtSM53D21srrFiRVLWRR4kOgVf8SY8RweyhAAAHbuRo0eYoHCErNVKjIiMZFxJpEYyWdZGYKXA46KEYwINMuiwgIAKuZEDmGhpdVb6EbeoCFkMvkrqoMrUaaWln1jyZladbaDQux5rUwMgbLXSlDc4FcNqcUa64jLSiGY/kgayu0P8AfmWgKaLpgOy9BNlwgJ1Z+uEZc0ucJRuTkM6bY8lnizv2WSIoJDDmPwLzqUOnfMlwzjb///EZWoSyJIUky2ieynkncoaNXIR5xtHcqSIoUGpdhFLETlGgCeBAElNOcuhx/DLB3uh7HMN080JQo9DxoX04YlLKd9ZscYW4z+Nh+hAGRGxyn67Mc7mVk28WtXPXX5ZNV7M3sUlbLRLlryf7yzTs87jn/tUYciy7buz2WlSndXd+VaE9S1vMYlEhHdR/8SwRE4MQ3g3SCAYAljm2MHzqDw0CgzGAiEMYMENGgsOSEFQqQAUNOqtMZEhBNEALrgw+kQ6LyNLWPIspHLU0LsjhUUhjBuTdINa5LJZNQ1cCqSqlsJdEAiMQA2RPGESJbzxnZxxFopIHtS5o4aC1Uw9BaCzLarDDmUEplYvNEqRwTRNLttMOh26///0F/NoNQZ0L6MPV4wHEwm07iszxFh6i5xVnFTLHuAPSIAAggJy2T//uyZO2EBf9jTatsPrByS9pqPMK6E/mPQY0kuQHGL+q9hiDgfPz2Sg6ORiWzgo6MQ3eek9WxnCfIhYEd70tR0pY4Rihzvc37sdFvTTdvDUsKOq4JQgb1QdEv+ulUqrT1Zp0DLHrM8fxL8irLSzry9UvF9evw3rzb8//Um8XedK26vcLw9RW/0b/+eoiVEmQgAWnOWePa3AJMzAYyw0zA0CjRo6NPEAS6wcwBIJKkIAMABRsEChEiDlxQEeOFM2CArvQzfeBujX5l+VfOy9ags4oio7Cd5w7DtqV0cg+mqR148GhV3mtT1LSSy/K8ddqZJHGci5l65ZSNvtsrtifb15hc5VpTEujxpOtbKqDbkAkMwL6QrYpiCDP/0p2///7M/hq0GoXcedX+jDbcYUKDx+YcMFz+OibAXFbkOjR1SL2KoGgCQAAmlKiWpAQxnk40RHlrc/ZoUL3sl8PW3JU7lLHoclOEEX2KnxbdX1HgwgKZ6TBUMD1tH+WpyyuT17TjaPLfbMnO36XA6C6RNNwFkcxUjHIDFDZARDFEok8zwhG2YOsxegY0tP5S/OQ54/ARRFXDigQPEhHSPxtrt7z8IRsGv/4kAzVnk60kNFGh0IGS0sHBggODAAzMKV+xlPIKiaNoCLhIcUuMVHzBwIIulMaeXOKYKDLgvrdg4OC25pdRV03aWYyKMpTJXZsZa/KbZ4Aw8OwbDooHsttFEdA7F586eFcwG1vN4YQ0YU3Sul1HCdnmiUhI2FXlLtLiZJz1bTkepBNaVQLs1+hKkUIdc1H//+WKm/////4T/6mmKRyRubJ/5O/+O6uoCjEGn8sor2vP//uyZPMABZljz8tMRyCErGpNYYOYFx2POC2xOIHzLyn09I4w0geC0TOkJI3i7GiSuFgoBtp2VdHsCUN0AQAS4IwU7rBfBakt5SDhmqxJk6oybhIKiyx3Y1G3LJoB9UkPXvRCMU9J3uZ6sl/XXQf2xVEM5tPWW1u0m9HIodDTMHws7k7Iq/SdSpVXCsWFmTE4URpf+WzqU58CC/1MMTMbCQg//7l6r+Bgzc/ESgDNKpPHYQXMSANWbCysQrDGjhGMVeuckCgBOIwJkg5gTSBZaUDCQFoYIIwbUoyZpOtSBYtH6FdSg6Q0ZdekoXeL/z0kdJx7bUKh9AhoXkQcU5QEoexpCO71+ZhQ3j/fhhtykpH1KwkpFAsdm295BesYTT22IHqc6ysJVO9KHZHyZz93+Hhs3////1P/pf91lH7+lGsg19oqRqNVhpjH+zUWhi2S1K4FGUcBBgDTdsu4GFsodIorxWWMUl5ZEH1qld65BBR4UMIWbaIxiRC5lLXxJXSDieffaOTm2IqQX//wlQuAtmdGel0ZoiF2ROMCNCgyhnpLIS59BL11jGAga035gyyh/+RaEpeclP+fqv8P/4P8CmQQW6AAASk44S+zUMwwYYQKNDxQcYIiy0Lh0omamGBKUAZOywDoeJTApAEFsJsbSkARmpOG81KlTSlyLOzNdBKRD8szY6oaIT2UNEoLigRDCpwLyPGaW2paqeFKK09eqGETMMyepe1UtQmSCm5Nyd0Mj6skloqIE3+CnRk2WfmA4a6Tli7cFYe8vaYXl//143/+TZvScvtX3+U1l4Glia0opLTUWkuoxzQQgLABAhpmsOUO//uyZOOABThgTotMNiJtyyqNYSN6FQVzQ609LUnRLyiw8xcYsgRYh6wDw4V5rIwqTDCCCzvSiMJnEQVjI3SrzI/hZpFTF0qxSunhjuL7cm8SV5mj9Mv//gSknVD3Dne2/Nfo4x8iE2LL3xNQ70NhZIcZ2pJM5tPQ3+Ua1OpHlIqNqVGYnRpfb9Dca9HcY9UYAAA0NIptkoJLhgB2LKoFQQYLAwXMCEV9zBf4GASHMAASaQGAAGoW2Dph5EOEQksGM4dH8QhsuamCQmpCgC9gqKiGw+kVyjSh9Djgv0q+AZ+GMaRxk2mJq4b+LTuEpaNCJNE6KNSWbliBZx9EWRMoSJKpE2NkaJCGptwFc/BCoQdAsTkZls6jqJR8OhIkoZBO9Cr8TpQ2XWMa9DvPMV0JOz/+jRMr9N3N1LtXe1K5EAfYDQNsayzJNAmNLqjiDxw5oDoACAAUwI2EU407TazNWYf9RZ5F40r00rG1VCqBezyR+M3lYbyg5cc5w9SrlzAhCQNyKtsfVjK2UnGlifJmZvZYxWHvvfmFL80ndahaRoc5XAS5lK7OhxpFYU1aq///a1/bQQaCornRkOpw5NWV20vtITw44IQJDCXBBMQAAACSUhgXp6AIkACEY8lKpJyhYUWXRVMCDRVLJColBtrDAWrAQsIwCfKqhDkaBmTS5N5CR2qg5mY2DiU6tYilLwzsLtTxr1fxmxMHnFOdWDszggVppUxCrBkjaXVNEmo0SpJ4QwqjSH1CjWKY4+jzBGspDWXmbRW9bfcyvgmpWo0XZyr8P47SqLxVh//2PSjoYlD/87v3/zIUU1RU/Nt6v0hVcah8//uyZPIABgtfTbN5S3B568n5YYKaFRFxQ609MQGsrmn09AopURaQIBppuW8WcAqQ1zTaqUTKpDsJnNHS4VL4XRlLWmAqJAlVFThx2iQ4gh0b81Hv4pRNf4eWXW6GMwkQ2Nejq7wiNX7qSqAiN2esrt//UU7eis9Ab1apXZ3DlOEI07KFdqMSrogi+KgnAx4EAGm8eh9TOYyWmOIhbwQM4KVQUUmIExjgIYGJozGYC5gAGYKFmDmoMHjRRgyd6NkFock1ZCaCRBliSYEBWRNdZS4MuLvLHRnL9EIKmIMAi111Pat1IBgcTQTQ0CWAcBNQCUhpEppPl7VCPJsqGA+Iptoptc00tvWxxfQ0scERFgeD4PgCRhWhCueaGnlyAvNQ0YXOgwaLD66A+JwL1ZojRoRGyYuQjgs6Nat+irZJNCr7n/+/6ylsjd75tdO//4s0c0ZT55y3TxLnW0unoEZQrkBCC1HrdoEoFEnIhL5gAPxS3EhwIEvJKnSmV4EwiNFzjz5xsJyroTJxjDv9bkp3GuQn/6osRIuUXYipwNvdvm8arz/xXNjLMocWhouKB08D2+DL/+e/uq59jGv9653uRDaeKOL6sqKL+DCdDxksIcfVbwK2U7/A5F41IQ3hQ04AyNQiJorBC0GHA4SsGbMEACgFToDmWnEHkC8GsG9TqYm1szSlDUiBFtqULhXAeB+AcgZEwNoawKXLCr7oMRWm5MCwCqWqzyKvw6pa6Zc2GXnXTKozehh3Ke1LxYcqaoeno9MoUYtMLq8Ti0fTFLZWbc/E+YzHKVyVnN2TSdSw5KfI3DigqFYQEznR/+v/zCC0qhhe//uyZPIGBmtfTStvTiB3i7qPJegMFmV3Ni0w/ImBKOm08woRr1Flj8tHRwoeJIqGo/UsNGKEio8MwIAAAAApOWHcC9UReVcbqmdolPoJegW1Gim6lLvLAt5Szm8Ui8EgJAo3ZlPQxCo35tkmwt7WlXq78+uiuqkO57s6HU/qb755PmY4UE3ddqL2Kcw7qHaV3DloUdW/zanqEAA5nqOGJXuYsCRmcWhDeAhLEgWCgYZNBBMBjBQCMECEiHRbkLCAEhEoG5iQKBDeKEymU096xoHGKxcHAlN0ugtYCAx1WRFpDB4NVsly62wonsRZ0PAxx1HAYA20h0oATX2hJvsODgm1FQJXiPL6NalEc9eLeOpLraxKXVRiYHiE6VLiIOxsHiI9Bs0J5QPYRGOCWwuPVirbLdO4TpHtHU5y57hykm3B+PANCuIUbnF///+TCaH5IjZQm3mCoPicVJCqsOlydxmIgd6lkxeXBXrkJhBccusQrL+Lx8MgYk4UG7w/g0KwDw+DgchwR1/1c0DAuFblD7uuFr+Km/zLtj5PZ0VxDR7PrsAjpnjlws6XG8qeZUcgbnn9Jb+W/2R+ECCf0pqGJkx2UKqnDLj2VABGpnfCkVYD8a/WGSACHIqRz40YeODxkYOIDBIUB7CQIGCMtU1WipUNCyQxggMOoJgIWYGZJHKelaTbqhQ1TMlyNjAYPXa+ycKW1iTQE4cIWJMLARl+akEylrEvbq7iv5XA8Nk3SqsGgvEsiHsTyJWnM8RL6GbyKjtzJISoXMlcdqmX7xUlyKZTISGrUW6Zl1591wwfY2KUGIHO+hGo3V/51MjI/rnudtMM//uyZO0GBnhezKuMVyBtCqqdMQOYFHlzOQ2wWsGMqCp1hgxw7GoZ+o2maw1ggAFtyalQBeAbEnyFSAhqZXBOFZdC5E/zKw7XT7fI/oft5EXlJfhSxg7G8ElY0IGrZYrP2/VJndTjfBsxAADFPPgK98j/6X+DJskX+Pl++jDuSZo7kQCsmZoLNBR75asnAE0cdTpJqMiBUOMJQmAcbTA4IAxRMBAscE4kBzBAQBJMMCggwOAzAgUMkgYyIDjHIhWHjBKDW4JlJdLTXSj+3rSX3GQAv0gCbh0jwpX35WwmOv6m9B7WZpwJbDa5UUHuWHgx/qSLSrOy9C0ly4cfwqjFALOQCoNtFRxZNkUlTIUBZdHA7TIWa8mZZApqqpCQ3nUFrhqBki+OdzBTNXPKg49d/sDKecw+bGuox1G59C4dkFrUvjHA7BiAACCzx3HaBODPP9OnGee35hpw50uX0+6HqKSL5F3MMijzIQ+WMNNMHmUZRRhDD273/pmis1Ch0cVO96Mosg4eEA4XdrL2rKa2UefN7cFnjQ8AKQ1SXbnuKDnHUgjdOX1/uklTSy6NDdp0Qao4Xo48Ycbki464cx74oi7lr4NdOxUGjWbo7FoBReZAdmaA5hpQZaZGalQkNmEiAKFk3QcAvaDQwyU4MvChEIm9yBxbFACsgxsN6EalbZEjMa2CxlMVFDOwFOXs+0Bu7BT9SWKJzK6rR9rL84sBU1jC5muzj/W70qnqtL2rS3iSWu4MFFkcOqZOSc3KcjNWCgFE4ls1X7HEqqWARLXl59Jf/5/tVygYlpyTzjVv/ciRIz6lqrzlPVgoS1VtfnAJKzZr//uyZPMOBcFezQuJLyKB6zoZPSiIFol/Lk3gz4mkrmj08w2w7/zQCASLouxSZFQAADThlx2g2QjKwW5RPrYggZSkOZzYUWSOSmWecckSl5nDQVZoBIkZz8pJ5YlzWNJjq6lSjGqkpqqrGZiz9SDCuf1avGP/+Mfw6epbMd///oUBX6pf6qvf4zH7al8PjcY/rHAzRFJKTEFNRTMuMTAwqqqqqqqqqqqqqqoYAADBK1nLaQUhJcUwTo6dVN5BhejsAcidALoH0kSFoTCliooSUfqKV6pL8LcOKOuRYVNJgFDJLFZohJUIpUEwVLgiKXImlkU5bHzLJPTzJRLTUTZYGSNIkZ5oBCTgpJzacFCYJJc7DiWsdpFGZ8wSSfOxLZbTUX7kcqq9U7U5HDpyq5pHDiKMIKmGDRRUkKCgAZAABhdPpWElJktyiokQvQ0T+ZifFiMEW4ykOfuCuvRfG8awkp0Euh0UxckkhR+siHM1pTljvcQ1bRrUPP46n0bOsvYj2aFbZnnAoTFNrsSMAQVstVU5GWJEkucRw4lppEjElJPPnDkaNVjepMBNhRIIBJqTGpUmaqufVKNQFAEmqxmbjVVgEKjcAmlg6gAgLJSag+T0BMMCcWDQVGik0lUlwjoCdWqGoYFY6OJDBbLKhkZqwNHGAgoOWVDVpZY5NfscmChgQeWOhlxZUMm7LHI//yZQwKo6GTLZUMmCggTx0NWWywyNZOUjVgtljkZf9lJlsuZGrSo5GrBQaOhkyhgR/X7OsaQAAfp2kouD4ynjUSQKKKtiyrztJl6JUenRVHoaSCVDM8fieWtZel+eWnRdQxB8XGzT//uyROSAJIRSRCnpNaKOy6iIPMPkDumg3OekYUIJLlokZhpZOzxuU/+5s0aKAj4tSyJISWZbPF5uzTs7GnHFxbOxpRR8Xm5UmtcblSzOz5s0aJMPi43HeNRqTjSij4uHZ2+58qSQkSIPQTVJf+wasDVREqZMQU1FMy4xMDCqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq";
+
+    const pads = Array.from(document.querySelectorAll('.pad'));
+
+    let audioCtx = null;
+    let audioBuffer = null;
+    let decodePromise = null;
+    const voices = {}; // padId -> currently-playing AudioBufferSourceNode
+
+    function getContext() {
+      if (!audioCtx) {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        audioCtx = new Ctx();
+      }
+      // Browsers start the context suspended until a user gesture.
+      if (audioCtx.state === 'suspended') audioCtx.resume();
+      return audioCtx;
+    }
+
+    function decodeOnce(ctx) {
+      if (audioBuffer) return Promise.resolve(audioBuffer);
+      if (!decodePromise) {
+        decodePromise = fetch(AUDIO_SRC)
+          .then((res) => res.arrayBuffer())
+          // Use the callback form too for older Safari compatibility.
+          .then((data) => new Promise((resolve, reject) => {
+            ctx.decodeAudioData(data, resolve, reject);
+          }))
+          .then((decoded) => { audioBuffer = decoded; return decoded; });
+      }
+      return decodePromise;
+    }
+
+    function stopVoice(padId) {
+      const current = voices[padId];
+      if (current) {
+        // Detach handler first so cutting off doesn't clear the playing state
+        // of the replacement voice we're about to start.
+        current.onended = null;
+        try { current.stop(); } catch (_) { /* already stopped */ }
+        voices[padId] = null;
+      }
+    }
+
+    function play(padId, padEl) {
+      const ctx = getContext();
+      decodeOnce(ctx).then((buffer) => {
+        // Cut off this pad's previous play before starting a fresh one.
+        stopVoice(padId);
+
+        const source = ctx.createBufferSource();
+        source.buffer = buffer;
+        source.connect(ctx.destination);
+        source.onended = () => {
+          if (voices[padId] === source) {
+            voices[padId] = null;
+            padEl.classList.remove('playing');
+          }
+        };
+        voices[padId] = source;
+        source.start(0);
+        padEl.classList.add('playing');
+      }).catch((err) => {
+        console.error('Could not play sound:', err);
+      });
+    }
+
+    pads.forEach((pad) => {
+      const padId = pad.dataset.pad;
+
+      const trigger = (e) => {
+        // pointerdown gives the snappiest, lowest-latency retrigger on touch.
+        e.preventDefault();
+        play(padId, pad);
+
+        // Re-arm the pulse animation on every tap, even mid-playback.
+        pad.classList.remove('trigger');
+        // Force reflow so the animation restarts.
+        void pad.offsetWidth;
+        pad.classList.add('trigger');
+      };
+
+      pad.addEventListener('pointerdown', trigger);
+      pad.addEventListener('animationend', () => pad.classList.remove('trigger'));
+
+      // Keyboard accessibility: Enter/Space fire the pad too.
+      pad.addEventListener('keydown', (e) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          e.preventDefault();
+          play(padId, pad);
+        }
+      });
+      // pointerdown already handled playback; stop the synthetic click.
+      pad.addEventListener('click', (e) => e.preventDefault());
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds `sound-board.html` — a single-file soundboard built on the html-tool template. It has **four mashable pads** laid out as a 2×2 grid that fills the mobile viewport without scrolling. Tapping a pad fires the viral **"fuaaa" / FAAAH** TikTok sound effect; tapping again before it finishes **cuts off the in-flight play and restarts it instantly**.

## How it works

- **Embedded audio in git:** the ~2s MP3 is inlined as a base64 `data:` URI, so the tool stays a single self-contained file *and* the audio bytes are versioned directly in git (no external asset host, no separate binary to fetch). The clip is the meme "FAAAH" sound (creator Tayleon); its integrity was sha256-verified against the source on download.
- **Web Audio retrigger:** the MP3 is decoded once into an `AudioBuffer`. Each pad owns its own "voice" (`AudioBufferSourceNode`). On tap, the pad stops its previous voice and starts a fresh one from `0` — clean cutoff + replay with no latency. Pads play independently of one another.
- **Mobile-first, no-scroll layout:** `#app` is a flex column at `100dvh`; the board grid grows to fill the remaining height. `overflow: hidden` plus `dvh` and `env(safe-area-inset-*)` padding keep all four pads on screen across phone chrome and notches. A short/landscape breakpoint hides the description and shrinks the header so four pads still fit.
- **Accessibility & feel:** real `<button>` pads (Enter/Space fire them), `:focus-visible` outlines, `prefers-reduced-motion` honored, ≥44px targets, and a pressed/playing state that fills the pad plus a quick pulse on every retrigger.

## Verification (headless Chrome via `uvx rodney`)

Served locally and driven with rodney at a 390×844 mobile viewport:

- **Layout:** 4 pads render in a 2×2 grid; document is not scrollable at the mobile viewport (`scrollHeight === clientHeight`).
- **Decode:** tapping a pad decodes the embedded MP3 to a **1.927s** `AudioBuffer` and starts a voice (`playing` state applied). *(Headless has no audio device, so the `AudioContext` reports `suspended`, but the full decode→source→start path executes; in a real browser a user gesture resumes it and the sound plays.)*
- **Retrigger/cutoff:** re-tapping the same pad mid-play replaces its voice with a new source node (`voiceReplaced: true`, still playing) — confirming cut-off-and-restart.
- **Independent voices:** firing pads 01/02/03 yields three concurrent active voices.

Mobile screenshots of the idle grid and the active/playing state were captured with rodney and shared separately (the gh-image release-asset host wasn't reachable from this session, so they were not embedded here to keep the repo binary-free).

## Notes

- `index.html` is generated and gitignored; CI rebuilds it on deploy, so it's not part of this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnJ5c77ZzMMBXGaW3pzuee)_