### PR TITLE
Fix sound-board silent on iOS (mute switch) by using media elements

### DIFF
--- a/sound-board.html
+++ b/sound-board.html
@@ -284,76 +284,40 @@
 
     const pads = Array.from(document.querySelectorAll('.pad'));
 
-    let audioCtx = null;
-    let audioBuffer = null;
-    let decodePromise = null;
-    const voices = {}; // padId -> currently-playing AudioBufferSourceNode
+    // Playback uses one HTMLAudioElement per pad instead of the Web Audio API.
+    // Why: on iOS, Web Audio output is silenced by the hardware Ring/Silent
+    // switch (and Low Power Mode), so the board can be dead-silent on a phone
+    // whose mute switch is on while working everywhere else. Media elements
+    // play through the normal media channel and are NOT muted by that switch,
+    // as long as the first play() runs inside a user gesture (the tap below).
+    // Each pad gets its own element so pads can overlap and each retriggers
+    // independently.
+    const players = pads.map(() => {
+      const audio = new Audio(AUDIO_SRC);
+      audio.preload = 'auto';
+      return audio;
+    });
 
-    function getContext() {
-      if (!audioCtx) {
-        const Ctx = window.AudioContext || window.webkitAudioContext;
-        audioCtx = new Ctx();
+    function play(padIndex, padEl) {
+      const audio = players[padIndex];
+      // Restart from the top. Seeking a playing element cuts it off and
+      // replays it — no pause()/play() race that can throw on mobile.
+      try { audio.currentTime = 0; } catch (_) { /* not seekable yet */ }
+      const result = audio.play();
+      if (result && typeof result.catch === 'function') {
+        result.catch((err) => console.error('Could not play sound:', err));
       }
-      // Browsers start the context suspended until a user gesture.
-      if (audioCtx.state === 'suspended') audioCtx.resume();
-      return audioCtx;
+      padEl.classList.add('playing');
     }
 
-    function decodeOnce(ctx) {
-      if (audioBuffer) return Promise.resolve(audioBuffer);
-      if (!decodePromise) {
-        decodePromise = fetch(AUDIO_SRC)
-          .then((res) => res.arrayBuffer())
-          // Use the callback form too for older Safari compatibility.
-          .then((data) => new Promise((resolve, reject) => {
-            ctx.decodeAudioData(data, resolve, reject);
-          }))
-          .then((decoded) => { audioBuffer = decoded; return decoded; });
-      }
-      return decodePromise;
-    }
-
-    function stopVoice(padId) {
-      const current = voices[padId];
-      if (current) {
-        // Detach handler first so cutting off doesn't clear the playing state
-        // of the replacement voice we're about to start.
-        current.onended = null;
-        try { current.stop(); } catch (_) { /* already stopped */ }
-        voices[padId] = null;
-      }
-    }
-
-    function play(padId, padEl) {
-      const ctx = getContext();
-      decodeOnce(ctx).then((buffer) => {
-        // Cut off this pad's previous play before starting a fresh one.
-        stopVoice(padId);
-
-        const source = ctx.createBufferSource();
-        source.buffer = buffer;
-        source.connect(ctx.destination);
-        source.onended = () => {
-          if (voices[padId] === source) {
-            voices[padId] = null;
-            padEl.classList.remove('playing');
-          }
-        };
-        voices[padId] = source;
-        source.start(0);
-        padEl.classList.add('playing');
-      }).catch((err) => {
-        console.error('Could not play sound:', err);
-      });
-    }
-
-    pads.forEach((pad) => {
-      const padId = pad.dataset.pad;
+    pads.forEach((pad, index) => {
+      players[index].addEventListener('ended', () => pad.classList.remove('playing'));
 
       const trigger = (e) => {
+        // Play synchronously inside the gesture so iOS unlocks/keeps audio.
         // pointerdown gives the snappiest, lowest-latency retrigger on touch.
         e.preventDefault();
-        play(padId, pad);
+        play(index, pad);
 
         // Re-arm the pulse animation on every tap, even mid-playback.
         pad.classList.remove('trigger');
@@ -369,7 +333,7 @@
       pad.addEventListener('keydown', (e) => {
         if (e.key === ' ' || e.key === 'Enter') {
           e.preventDefault();
-          play(padId, pad);
+          play(index, pad);
         }
       });
       // pointerdown already handled playback; stop the synthetic click.


### PR DESCRIPTION
## The bug

A friend's phone played nothing while the board worked elsewhere. Cause: the board played through the **Web Audio API** (`AudioContext` + `AudioBufferSourceNode`), and **iOS silences Web Audio output whenever the hardware Ring/Silent switch is on** (also under Low Power Mode). So on an iPhone with the mute switch flipped, the pads were dead-silent — the classic "works on my phone, not my friend's" soundboard symptom.

## The fix

Play through one **`<audio>` media element per pad** instead of Web Audio:

- Media elements play through the normal **media channel**, which is **not** muted by the iOS silent switch (the reason audio libraries fall back to HTML5 Audio on iOS).
- Playback now runs **synchronously inside the tap gesture**, removing the prior fragility of starting the sound in an async callback after `decodeAudioData` — iOS is much happier unlocking audio that way.
- Behavior preserved: each pad keeps its own element so pads overlap and each **retriggers independently**; seeking `currentTime = 0` cuts off and replays with no `pause()`/`play()` race.

No change to the UI, layout, or the embedded base64 audio.

## Verification (headless Chrome via `uvx rodney`)

- 4 pads each wired to their own `Audio` element sourced from the embedded data URI; `readyState 4` (fully loaded).
- Tapping a pad calls `play()` within the gesture, resets `currentTime` to 0, and applies the `playing` state — no JS errors.
- Re-tapping retriggers (currentTime back to 0); tapping a second pad plays it independently (both `playing`).

Note: headless Chrome has no audio device, so this confirms the play path/wiring rather than audible output. The substantive change — media element vs. Web Audio — is specifically what restores sound on a muted iPhone, which can only be fully confirmed on-device.

## To confirm on the friend's iPhone

Open the page and tap a pad. If the ringer/silent switch is **on**, you should now still hear it (you wouldn't before). Volume buttons still control loudness as usual.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GnJ5c77ZzMMBXGaW3pzuee)_