### PR TITLE
Add pre-commit CI workflow for PRs

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,28 @@
+name: pre-commit
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Run pre-commit
+        run: uv run pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
Add a GitHub Actions workflow that runs pre-commit on every pull request.

## What
- New workflow `.github/workflows/pre-commit.yml`, triggered on `pull_request`.
- Runs `uv run pre-commit run --all-files --show-diff-on-failure`.
- Least-privilege permissions (`contents: read`).
- Caches uv downloads (`setup-uv` `enable-cache`) and pre-commit hook environments (`~/.cache/pre-commit`, keyed on `.pre-commit-config.yaml`).

## Why this shape
Runs pre-commit through `uv` rather than the official `pre-commit` GitHub Action, so CI uses the version pinned in `pyproject.toml` / `uv.lock` (`pre-commit>=4.6.0,<5`) — the same version used locally.

## Notes
- Action versions are current as of this PR: `checkout@v7`, `setup-uv@v8.3.2` (SHA-pinned), `cache@v6`.
- `--all-files` lints the whole tree on each PR (matches how it was run locally); scoping to the diff would be a deliberate follow-up.
- To gate merges, this must be added as a required status check in branch-protection settings (a GitHub repo setting, not something the workflow declares).
- `pages.yml` was intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)