### PR TITLE
Install pre-commit hooks in remote session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -6,35 +6,50 @@ if [[ "${CLAUDE_CODE_REMOTE:-}" != "true" ]]; then
   exit 0
 fi
 
-# Skip if gh is already installed
-if command -v gh &>/dev/null; then
-  exit 0
-fi
-
-# The goal here is to install `gh`. For some bizarre reason, Anthropic doesn't
-# provision their boxes with a `gh` tool. They ship a ton of other dev tools but
-# not `gh`.
-
-# Resolve latest version from GitHub's redirect
-GH_VERSION=$(curl -sI https://github.com/cli/cli/releases/latest | grep -i '^location:' | sed 's/.*tag\/v//' | tr -d '\r')
-
-if [[ -z "$GH_VERSION" ]]; then
-  echo "Failed to resolve gh version" >&2
+# Everything below depends on uv; fail loudly up front rather than partway in.
+if ! command -v uv &>/dev/null; then
+  echo "uv not present; cannot continue" >&2
   exit 1
 fi
 
-echo "Installing gh v${GH_VERSION}..."
+# Sync the Python environment and set up the pre-commit git hook. Remote boxes
+# start with a bare checkout, so without this the hooks in
+# .pre-commit-config.yaml never run on commits made from a remote session.
+echo "Syncing Python environment..."
+uv sync
+uv run pre-commit install
 
-# Download and extract into a temporary directory
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
+install_gh() {
+  # The goal here is to install `gh`. For some bizarre reason, Anthropic doesn't
+  # provision their boxes with a `gh` tool. They ship a ton of other dev tools but
+  # not `gh`.
 
-curl -fL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o "$tmpdir/gh.tar.gz"
-tar -xzf "$tmpdir/gh.tar.gz" -C "$tmpdir"
+  # Resolve latest version from GitHub's redirect
+  GH_VERSION=$(curl -sI https://github.com/cli/cli/releases/latest | grep -i '^location:' | sed 's/.*tag\/v//' | tr -d '\r')
 
-# Install to ~/.local/bin
-mkdir -p ~/.local/bin
-mv "$tmpdir/gh_${GH_VERSION}_linux_amd64/bin/gh" ~/.local/bin/gh
-chmod +x ~/.local/bin/gh
+  if [[ -z "$GH_VERSION" ]]; then
+    echo "Failed to resolve gh version" >&2
+    exit 1
+  fi
 
-echo "Installed: $(~/.local/bin/gh --version)"
+  echo "Installing gh v${GH_VERSION}..."
+
+  # Download and extract into a temporary directory
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  curl -fL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o "$tmpdir/gh.tar.gz"
+  tar -xzf "$tmpdir/gh.tar.gz" -C "$tmpdir"
+
+  # Install to ~/.local/bin
+  mkdir -p ~/.local/bin
+  mv "$tmpdir/gh_${GH_VERSION}_linux_amd64/bin/gh" ~/.local/bin/gh
+  chmod +x ~/.local/bin/gh
+
+  echo "Installed: $(~/.local/bin/gh --version)"
+}
+
+# Skip if gh is already installed
+if ! command -v gh &>/dev/null; then
+  install_gh
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,13 @@ dependencies = [
     "livereload>=2.7.1",
     "pre-commit>=4.6.0,<5",
 ]
+
+# We intentionally do not specify the uv version required with a minimum. This
+# repo makes heavy use of Anthropic remote sessions, which provision a box with
+# a uv version that can vary with ours. If we specify a minimum version here
+# that's higher than the version they install, a bunch of our commands
+# immediately bomb. To avoid managing that or trying to pin to whatever they
+# install with a matching minimum required version, we instead just don't pin at
+# all and rely on theirs. We haven't encountered any critical features yet that
+# we want out of newer uv versions that the older versions encountered in their
+# provisioned image doesn't yet have.


### PR DESCRIPTION
## Problem

`pre-commit` was recently added to the project, but nothing installs its git hook on remote (Claude Code on the web) sessions — remote boxes start with a bare checkout, so the hooks in `.pre-commit-config.yaml` silently never run on commits made there.

There was also a latent bug for anyone extending this script: it exited early when `gh` was already installed, so any setup appended after that check would be skipped.

## Changes

- `session-start.sh` fails fast with a descriptive error (`uv not present; cannot continue`) if `uv` is missing, since everything below depends on it
- It then runs `uv sync` and `uv run pre-commit install` unconditionally in remote environments
- The `gh` install is moved into an `install_gh` function guarded by its own `command -v` check, instead of an early `exit 0` that would skip everything after it
- `pyproject.toml` documents why uv has no minimum version pin: remote boxes provision their own uv version, and pinning a newer minimum would make every uv command fail there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
