### PR TITLE
Move gh install from SessionStart hook to environment setup script

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -19,37 +19,11 @@ echo "Syncing Python environment..."
 uv sync
 uv run pre-commit install
 
-install_gh() {
-  # The goal here is to install `gh`. For some bizarre reason, Anthropic doesn't
-  # provision their boxes with a `gh` tool. They ship a ton of other dev tools but
-  # not `gh`.
-
-  # Resolve latest version from GitHub's redirect
-  GH_VERSION=$(curl -sI https://github.com/cli/cli/releases/latest | grep -i '^location:' | sed 's/.*tag\/v//' | tr -d '\r')
-
-  if [[ -z "$GH_VERSION" ]]; then
-    echo "Failed to resolve gh version" >&2
-    exit 1
-  fi
-
-  echo "Installing gh v${GH_VERSION}..."
-
-  # Download and extract into a temporary directory
-  tmpdir=$(mktemp -d)
-  trap 'rm -rf "$tmpdir"' EXIT
-
-  curl -fL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o "$tmpdir/gh.tar.gz"
-  tar -xzf "$tmpdir/gh.tar.gz" -C "$tmpdir"
-
-  # Install to ~/.local/bin
-  mkdir -p ~/.local/bin
-  mv "$tmpdir/gh_${GH_VERSION}_linux_amd64/bin/gh" ~/.local/bin/gh
-  chmod +x ~/.local/bin/gh
-
-  echo "Installed: $(~/.local/bin/gh --version)"
-}
-
-# Skip if gh is already installed
+# gh is installed by the environment's setup script (source of truth:
+# .claude/setup-script.sh, pasted into the environment settings GUI). It is
+# baked into the cached environment snapshot, so it should already be present;
+# warn rather than fail if the setup script hasn't been synced to the GUI.
 if ! command -v gh &>/dev/null; then
-  install_gh
+  echo "WARNING: gh not found. The environment's setup script may be missing" >&2
+  echo "or stale; see .claude/setup-script.sh for the sync procedure." >&2
 fi

--- a/.claude/setup-script.sh
+++ b/.claude/setup-script.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Setup script for Claude Code on the web (cloud environments).
+#
+# Last-edited commit: PENDING-STAMP
+#
+# This file is NOT executed from the repo. It is the version-controlled source
+# of truth for the environment's "Setup script" field, which can only be set by
+# pasting into the GUI: claude.ai/code -> environment settings -> Setup script.
+#
+# Keeping them in sync (manual, hokey, but the only option today):
+#   1. Edit this file and commit.
+#   2. Replace the "Last-edited commit" sha above with `git rev-parse --short
+#      HEAD` and commit again (the stamp commit).
+#   3. Paste the whole file into the environment's Setup script field.
+# To check whether the GUI copy is stale, compare its stamp against:
+#   git log --oneline -2 -- .claude/setup-script.sh
+#
+# How this differs from .claude/hooks/session-start.sh:
+#   - This runs as root on Ubuntu 24.04, BEFORE Claude Code launches, and only
+#     when no cached environment snapshot exists (the filesystem is snapshotted
+#     after it succeeds, so installs here are effectively free on later
+#     sessions). Install system tools the cloud lacks here.
+#   - The SessionStart hook runs on EVERY session (including resumes, and
+#     locally) and handles per-clone project setup: uv sync, pre-commit install.
+#
+# Constraints (per https://code.claude.com/docs/en/claude-code-on-the-web):
+#   - A non-zero exit blocks the session from starting, so non-critical steps
+#     are best-effort (`|| ...`).
+#   - Keep total runtime under ~5 minutes or the environment cache won't build.
+#   - Network is subject to the environment's network access policy. Stock
+#     Ubuntu mirrors (archive.ubuntu.com) are reachable; cli.github.com and
+#     github.com are currently NOT, so gh comes from Ubuntu's repo (2.45.x).
+#     For a newer gh, add github.com + cli.github.com to the environment's
+#     allowed domains (or switch to Trusted access) and swap in GitHub's
+#     official apt repo.
+
+set -uo pipefail
+
+echo "Installing gh from Ubuntu archive..."
+apt-get update
+apt-get install -y gh || echo "WARNING: gh install failed; continuing without it" >&2
+
+gh --version || true

--- a/.claude/setup-script.sh
+++ b/.claude/setup-script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Setup script for Claude Code on the web (cloud environments).
 #
-# Last-edited commit: PENDING-STAMP
+# Last-edited commit: 02481cb
 #
 # This file is NOT executed from the repo. It is the version-controlled source
 # of truth for the environment's "Setup script" field, which can only be set by


### PR DESCRIPTION
## Problem

The SessionStart hook's `install_gh` curl-based installer hit `github.com` directly, which the remote environment's network policy 403-blocks at the proxy. Under `set -euo pipefail` this made the hook fail on every remote session — after the useful parts (`uv sync`, `pre-commit install`) had already run, so the failure was pure noise plus a missing `gh`.

## Change

Claude Code on the web now has first-class [setup scripts](https://code.claude.com/docs/en/claude-code-on-the-web#setup-scripts): they run as root on Ubuntu 24.04 before Claude launches, `apt install` works (verified live — stock Ubuntu noble repos are reachable through the proxy), and the resulting filesystem is snapshotted into the environment cache so the install happens once instead of on every session. The docs' own example setup script is installing `gh` via apt.

- **`.claude/setup-script.sh`** (new): installs `gh` from the Ubuntu archive via apt. This file is the version-controlled source of truth for the environment's **Setup script** GUI field; the header documents the paste-and-stamp sync procedure and carries a `Last-edited commit` sha for staleness checks.
- **`.claude/hooks/session-start.sh`**: drops `install_gh` entirely; keeps the per-clone project setup (`uv sync`, `pre-commit install`) per the docs' setup-script-vs-SessionStart-hook split, and warns (without failing) if `gh` is absent, pointing at the setup script.

## Follow-up required (manual, one-time)

Paste `.claude/setup-script.sh` into the environment settings at claude.ai/code → environment → **Setup script** field. Until then, sessions simply log the warning.

## Notes

- Ubuntu's `gh` is 2.45.0. GitHub's own apt repo (`cli.github.com`) serves current builds but is blocked by this environment's network policy; adding `github.com` + `cli.github.com` to the environment's allowed domains would enable it.
- Each edit to the setup script is two commits (substantive change + sha stamp), so compare the GUI copy against `git log --oneline -2 -- .claude/setup-script.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7bGXF8FkbfEWboSq5y2Dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7bGXF8FkbfEWboSq5y2Dk)_