### PR TITLE
Prune and consolidate html-tool skill

### DIFF
--- a/.claude/skills/html-tool/SKILL.md
+++ b/.claude/skills/html-tool/SKILL.md
@@ -7,27 +7,17 @@ description: Build and modify single-file HTML tools in this repository. Use whe
 
 Treat this skill as the current best-practice source for root-level single-file HTML tools in this repo. Use existing tools as examples, not standards: they may reflect older patterns. When editing, preserve the file's architecture. When creating or touching new areas, follow current skill guidance unless the tool has a clear reason to differ.
 
-Build every tool as a single self-contained HTML file in the repo root. Default to zero external dependencies, no build step, and vanilla JS. GitHub Pages serves these files statically at `tools.jonathandemirgian.com`.
-
-## Editorial Contract
-
-Treat the skill files as the only design authority.
-
-- `SKILL.md` defines policy, invariants, and exception rules.
-- `assets/template.html` defines the canonical visual defaults and token values.
-- `references/patterns.md` defines token-aligned optional patterns for non-trivial tools.
-
-Repeat policy in prose, not raw CSS values. The template should be the single source of truth for exact color, spacing, and type tokens.
+Build every tool as a single self-contained HTML file in the repo root. GitHub Pages serves these files statically at `tools.jonathandemirgian.com`.
 
 ## Start Here
 
 ### Create a New Tool
 
-Hard rule: do not hand-author a new tool file from scratch, and do not use a "create new file" shortcut that bypasses the template. The first change to the new tool file must be based on a copied `assets/template.html`.
+Hard rule: do not hand-author a new tool file from scratch, and do not use a "create new file" shortcut that bypasses the canonical template. The first change to the new tool file must be a copied `assets/template.html`.
 
 Preflight (do this before you add any app-specific HTML/CSS/JS):
 1. From the repository root, copy the template: `cp .claude/skills/html-tool/assets/template.html <repo-root>/{tool-name}.html`
-2. Quick verification (optional but recommended): the new file should start out identical to the template (except you have not yet edited it). If you need confidence, `cmp` the two files before you start building features.
+2. Confirm the copy succeeded: `cmp .claude/skills/html-tool/assets/template.html {tool-name}.html` should report the files identical before you edit.
 3. Replace `TOOL_TITLE` and `TOOL_DESCRIPTION` placeholders
 4. Decide whether the tool is simple or non-trivial
 5. If it is non-trivial, read [references/patterns.md](references/patterns.md) before implementing
@@ -38,7 +28,7 @@ Preflight (do this before you add any app-specific HTML/CSS/JS):
 1. Read the full file first
 2. Preserve its current architecture and overall patterns
 3. Apply current skill guidance to new or newly touched details
-4. If older local patterns differ meaningfully from current best practice, call that out as separate follow-up work instead of silently expanding scope
+4. If older local patterns differ meaningfully from current best practice, check with the user before modernizing them; otherwise flag it as separate follow-up work instead of silently expanding scope
 
 ### File Naming
 - Keep file names lowercase and hyphen-separated: `day-visualizer.html`, `color-picker.html`
@@ -46,16 +36,13 @@ Preflight (do this before you add any app-specific HTML/CSS/JS):
 
 ## Non-Negotiable Constraints
 
-- Keep all HTML, CSS, and JS in one self-contained root-level `.html` file
-- Skip any build step; GitHub Pages serves the file as-is
-- Prefer vanilla JS; add a CDN library only when vanilla JS is clearly insufficient
-- Ensure the tool works when opened directly in a browser
+- Keep all HTML, CSS, and JS inline in one root-level `.html` file; skip any build step
+- Default to zero external dependencies and vanilla JS; add a CDN library only when vanilla JS is clearly insufficient, and pin it to an exact version (`@x.y.z`, never `@latest`)
 - Make the layout mobile-friendly and responsive
-- Pin exact CDN versions whenever a library is needed
 
 ## Defaults For Every New Tool
 
-Start from `assets/template.html`. It is the baseline scaffold and canonical default implementation: document structure, semantic color tokens, spacing/type tokens, field and button styling, and responsive rules. Only deviate with a clear reason.
+Start from the canonical template (`assets/template.html`): document structure, semantic color tokens, spacing/type tokens, field and button styling, and responsive rules. Only deviate with a clear reason. Repeat policy in prose, not raw CSS values — the canonical template owns the exact color, spacing, and type tokens.
 
 Default visual goal: boring, comfortable, utility-first UI. Prefer readability and predictable hierarchy over novelty.
 
@@ -69,10 +56,8 @@ When reviewing the implementation, still check a few high-signal defaults that a
 - Use `:focus-visible` instead of custom `:focus` styles
 - Aim for `44x44` CSS px touch targets for primary controls; do not go below `24x24` in dense layouts
 - Prefer shared spacing/type tokens over ad hoc one-off values in newly touched UI
-- Add helper functions and extra UI only when the tool needs them; use [references/patterns.md](references/patterns.md) for toasts, clipboard actions, app-level errors, dialogs, and other opt-in behaviors
+- Add helper functions and extra UI only when the tool needs them
 - If the tool has shared interactive state, use a centralized `state` object plus `render()` instead of ad hoc DOM mutation
-
-See `Shared Styling Defaults` in [references/patterns.md](references/patterns.md) for deeper snippets and rationale around colors, layout, touch targets, and responsive refinements.
 
 ## Open Patterns When Needed
 
@@ -85,42 +70,9 @@ Open [references/patterns.md](references/patterns.md) before implementing when t
 - Shareable or bookmarkable state in the URL or hash
 - External libraries
 - Reusable interaction patterns like toasts, clipboard actions, app-level errors, or show/hide sections
+- Deeper styling snippets or rationale than the template covers (colors, layout, touch targets, responsive refinements)
 
-If none of those apply and the tool is mostly a direct input -> process -> output flow, the template baseline is probably enough.
-
-## Pattern Index
-
-Use this section for routing only. Read [references/patterns.md](references/patterns.md) for the actual implementation details.
-
-### Architecture
-- `Simple Stateless Tool` — Read when the tool is mostly a direct input -> process -> output flow with no shared app state.
-- `Interactive App with State` — Read when multiple controls or views mutate shared state or the UI is derived from combined state.
-- `Tool with CDN Libraries` — Read when vanilla JS is insufficient and a pinned external library is needed.
-
-### Common Interaction Patterns
-- `Copy to Clipboard Button` — Read when users can copy generated content.
-- `Toast Notification` — Read when feedback should be brief and non-blocking.
-- `Error Display` — Read when a failure affects the whole form or app, not just one field.
-- `Form Field + Validation` — Read when inputs need labels, hints, native validation, or field-level errors.
-- `Loading State` — Read when a user action triggers async work.
-- `File Drag & Drop` — Read when users can import files by dropping or selecting them.
-- `Modal Dialog` — Read when the tool opens a secondary flow or overlay.
-- `Confirmation Dialog` — Read when an action is destructive or hard to undo.
-- `Show/Hide Sections` — Read when UI regions are conditionally revealed.
-
-### Data + State
-- `URL State Persistence` — Read when tool state should be shareable or bookmarkable.
-- `Hash-based State` — Read when only a small amount of state needs to be encoded in the URL.
-
-### Libraries
-- `External Libraries` — Read when choosing a library or CDN loading strategy.
-
-## Modifying Existing Tools
-
-- Read the full file first
-- Follow the file's CURRENT architecture and naming patterns, unless explicitly told otherwise.
-- Apply defaults from patterns.md or template.html ONLY for functionality that is being added.
-- If you notice opportunities for modernization/updating the requested tool against content in patterns.md/template.html, explicitly check with the user that they want to modernize.
+`patterns.md` opens with a Pattern Index that routes each of these to the exact snippet. If none apply and the tool is mostly a direct input -> process -> output flow, the template baseline is probably enough.
 
 ## Local Testing
 

--- a/.claude/skills/html-tool/references/patterns.md
+++ b/.claude/skills/html-tool/references/patterns.md
@@ -6,13 +6,35 @@ Use it to choose an architecture, apply reusable interaction patterns, persist s
 
 These patterns are opt-in. `assets/template.html` provides the baseline scaffold, but it does not preload optional helper markup, CSS, or JS.
 
-## Table of Contents
+## Pattern Index
 
-- [Architecture Patterns](#architecture-patterns)
-- [Shared Styling Defaults](#shared-styling-defaults)
-- [UI Component Patterns](#ui-component-patterns)
-- [Data & State Patterns](#data--state-patterns)
-- [External Libraries](#external-libraries)
+Routing only — jump to the section below for the implementation details.
+
+### [Architecture Patterns](#architecture-patterns)
+- `Simple Stateless Tool` — the tool is mostly a direct input -> process -> output flow with no shared app state.
+- `Interactive App with State` — multiple controls or views mutate shared state, or the UI is derived from combined state.
+- `Tool with CDN Libraries` — vanilla JS is insufficient and a pinned external library is needed.
+
+### [Shared Styling Defaults](#shared-styling-defaults)
+- Deeper snippets and rationale for the font stack, color tokens, layout, spacing/type, touch targets, and responsive breakpoint.
+
+### [UI Component Patterns](#ui-component-patterns)
+- `Copy to Clipboard Button` — users can copy generated content.
+- `Toast Notification` — feedback should be brief and non-blocking.
+- `Error Display` — a failure affects the whole form or app, not just one field.
+- `Form Field + Validation` — inputs need labels, hints, native validation, or field-level errors.
+- `Loading State` — a user action triggers async work.
+- `File Drag & Drop` — users can import files by dropping or selecting them.
+- `Modal Dialog` — the tool opens a secondary flow or overlay.
+- `Confirmation Dialog` — an action is destructive or hard to undo.
+- `Show/Hide Sections` — UI regions are conditionally revealed.
+
+### [Data & State Patterns](#data--state-patterns)
+- `URL State Persistence` — tool state should be shareable or bookmarkable.
+- `Hash-based State` — only a small amount of state needs to be encoded in the URL.
+
+### [External Libraries](#external-libraries)
+- Choosing a library or CDN loading strategy.
 
 ---
 


### PR DESCRIPTION
Applies the writing-great-skills framework to the `html-tool` skill, targeting duplication, no-ops, and a missing leading word. Behavior is unchanged — pure pruning and consolidation. `SKILL.md` drops from 131 to 83 lines.

## Changes

- **Duplication:** Merged the two near-identical edit-flow sections (`Edit an Existing Tool` and `Modifying Existing Tools`) into one, preserving the "check with the user before modernizing" nuance.
- **Progressive disclosure:** Collapsed the four separate pointers at `patterns.md` into a single trigger list, and relocated the `Pattern Index` into `patterns.md` so the catalog is co-located with the content it routes to (loaded only when that file opens).
- **No-op:** Replaced the hedged "optional but recommended… if you need confidence" preflight step with a checkable `cmp` criterion, and cut the "works when opened directly in a browser" constraint (guaranteed by construction, and wrong for the CDN/ES-module tools the skill endorses).
- **Leading word:** Introduced `canonical template` as the single term for the template's role (previously named five different ways) and dissolved the `Editorial Contract` section into its one surviving rule, folded into `Defaults`.\n- **Constraints:** Trimmed the intro to pure framing and consolidated `Non-Negotiable Constraints` from 6 bullets to 3.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)