### PR TITLE
Bump outdated GitHub Actions in pages.yml deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Build redirect pages
         run: uv run python scripts/build_redirects.py
@@ -40,7 +40,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: '.'
 


### PR DESCRIPTION
Closes #81.

Bumps the actions on the live GitHub Pages deploy path to their latest releases:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v6` | `v7` |
| `astral-sh/setup-uv` | `v8.0.0` (`cec2083`) | `v8.3.2` (`11f9893b081a58869d3b5fccaea48c9e9e46f990`) |
| `actions/upload-pages-artifact` | `v4` | `v5` |

`configure-pages@v6` and `deploy-pages@v5` are already current and left unchanged.

## Changelog review

Each bump was checked against its upstream release notes before landing:

- **checkout v6 → v7** — v7's only behavioral change is blocking fork-PR checkout under `pull_request_target` / `workflow_run` triggers. This workflow runs on `push` (to `main`) and `workflow_dispatch` with a same-repo checkout, so it is unaffected. `fetch-depth: 0` is unchanged. Drop-in.
- **setup-uv v8.0.0 → v8.3.2** — minor bumps within v8; no breaking changes. Adds security hardening (scoped GitHub tokens, fetch timeouts) plus opt-in features. SHA `11f9893b081a58869d3b5fccaea48c9e9e46f990` verified against the `v8.3.2` tag; trailing version comment updated to match.
- **upload-pages-artifact v4 → v5** — the underlying `upload-artifact` backend was bumped and an opt-in `include-hidden-files` input added (defaults `false`). Default artifact output is unchanged from v4 (dotfiles and `.git`/`.github` still excluded), and it remains compatible with `deploy-pages@v5`. Note: the existing v4 + `deploy-pages@v5` pairing was **not** actually mismatched — the majors are versioned independently — so this is routine hygiene, not a compatibility fix.

## Verification

A Pages deploy runs on push to `main` / `workflow_dispatch`; confirm the deploy succeeds after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)