### PR TITLE
Add testing-html-app skill

### DIFF
--- a/.claude/skills/testing-html-app/SKILL.md
+++ b/.claude/skills/testing-html-app/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: testing-html-app
+description: Test a single-file HTML tool by driving it in a real browser. Use when asked to test an HTML tool or app, verify a tool still works, or check a change end-to-end in the browser.
+---
+
+# Testing an HTML App
+
+Drive the tool in a real headless browser with `rodney` (Chrome automation CLI, run as `uv run rodney <cmd>`). Testing means *exercising the tool the way a user would and observing what actually happens* — not reading the source and reasoning about it.
+
+## Loop
+
+1. **Launch.** `uv run rodney start`, then `uv run rodney open "file://$PWD/<tool>.html"`. (For tools that fetch or need a server, run `uv run livereload . --port 8000` first and open `http://localhost:8000/<tool>.html`.)
+2. **Exercise.** Take the tool's main path a real user takes: enter values (`input`, `select`), press things (`click`), then `waitstable`. Read what changed with `js "<expression>"`.
+3. **Verify.** After each meaningful interaction, confirm the result — `screenshot <file.png>` then read the PNG to see it, and `assert "<js expression>" -m "<what should be true>"` for exact checks (exit 1 = mismatch). Report every mismatch; don't smooth it over.
+4. **Stop** with `uv run rodney stop` when done.
+
+Run `uv run rodney --help` for the full command surface. Reach for `count`, `exists`, `visible`, and `ax-tree` to inspect structure.
+
+## Notes
+
+- `js` takes a plain JavaScript expression and prints its value: `uv run rodney js "document.querySelector('#total').textContent"`.
+- Always `waitstable` between an interaction and the check that reads its result.
+- Done means: the main path ran in the browser and every check either passed or is reported as a real mismatch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "click>=8,<9",
     "livereload>=2.7.1",
     "pre-commit>=4.6.0,<5",
+    "rodney>=0.0.4,<1",
 ]
 
 # We intentionally do not specify the uv version required with a minimum. This

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,21 @@ wheels = [
 ]
 
 [[package]]
+name = "rodney"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d8/61fb75202eb13a89bf51c3978c8f82d5a04250d1e626da764a8c6b03dd1a/rodney-0.4.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:7b351394f80960cb903df07994b5a4956cee08246c2dfc4c9e2c637a8cab3b79", size = 11903573, upload-time = "2026-02-17T22:57:54.386Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/47/448e940e44f36058b5b9d8b06c8ed8719680f7fcf8ecc90beeefe47277dc/rodney-0.4.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d3c0831ed8a029f23f19da9175a20082619eeeed344b56d71a3650de1e54f794", size = 11554714, upload-time = "2026-02-17T22:57:57.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f2/9c01e9e99c45a1d5abbb9561cf472ff320ca3c9985c92e10f40e0329cc59/rodney-0.4.0-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:c74ba09b82d46458abe21111bc324f02a3d61594fb289e10de59e00315d6ea26", size = 11084050, upload-time = "2026-02-17T22:57:59.851Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/29/6e6cf566571353f90bce0a9027e43277c22ea2617df906c1cda51d4be08e/rodney-0.4.0-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:5d34528bf63f44029f9a571176bd59fbd8b0e51cd8430befbdae07ef3b9d4194", size = 11481361, upload-time = "2026-02-17T22:58:02.362Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/60/d90b1c803c4f87459d5a2e7f7bb225e25c3ffa732123a84cae17515d74c5/rodney-0.4.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b009bd05d165b4cc41cba4688267dd0fb62d0bfcc53fe925f15d324fccde5917", size = 11084050, upload-time = "2026-02-17T22:58:05.481Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/52/6251ce66777523f8d08aac06c2668e9d1aae4334bf66f41a0e71bfe8cd76/rodney-0.4.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:4927959cd8d6a4768654336e5320ac41f82a554de1253304459d3d40df4679c2", size = 11481363, upload-time = "2026-02-17T22:58:08.439Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0f/1fbc12c3b7ce6abb70e26e078f84da30b5ca833d198ef4af575e8e7fec10/rodney-0.4.0-py3-none-win_amd64.whl", hash = "sha256:8ae4d429c3de7f938af9a851dd90b9fd4c831fb8e49b906ac941effead130d05", size = 10524251, upload-time = "2026-02-17T22:58:10.848Z" },
+    { url = "https://files.pythonhosted.org/packages/18/db/bffb283af3be3fa45c8d8332757d0adb58d9b6333209f07bb20f86b5fa23/rodney-0.4.0-py3-none-win_arm64.whl", hash = "sha256:524bf8ec5548ef4c859c99f5f0d056dd38e74539ae65efff04f7a23963850b07", size = 9949786, upload-time = "2026-02-17T22:58:13.565Z" },
+]
+
+[[package]]
 name = "tools"
 version = "0.1.0"
 source = { virtual = "." }
@@ -162,6 +177,7 @@ dependencies = [
     { name = "click" },
     { name = "livereload" },
     { name = "pre-commit" },
+    { name = "rodney" },
 ]
 
 [package.metadata]
@@ -169,6 +185,7 @@ requires-dist = [
     { name = "click", specifier = ">=8,<9" },
     { name = "livereload", specifier = ">=2.7.1" },
     { name = "pre-commit", specifier = ">=4.6.0,<5" },
+    { name = "rodney", specifier = ">=0.0.4,<1" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #30.

## What

A new minimal, model-invoked skill, `testing-html-app`, that instructs an agent to test a single-file HTML tool by driving it in a real headless browser (via [`rodney`](https://pypi.org/project/rodney/)) — exercising the tool the way a user would and observing what actually happens, rather than reading the source and reasoning about it.

The skill is deliberately small: one launch → exercise → verify → stop loop, plus the two non-obvious gotchas (`js` takes a plain expression; `waitstable` before reading a result). It points to `uv run rodney --help` for the full command surface instead of duplicating it, so it won't drift as rodney changes. The intent is to grow it as we use it over time.

Also adds `rodney` as a project dependency, since the skill runs it through `uv run rodney`.

## Testing

Dogfooded the skill loop against `lehmer-code.html` and `rank-vote.html`: launched headless Chrome, set inputs, clicked buttons, read state back, screenshotted, and ran `assert` checks — all working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)