### PR TITLE
Fix Pages deploy: use timezone-aware fallback in index sort

### DIFF
--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -4,7 +4,7 @@ import argparse
 from dataclasses import dataclass
 import json
 import subprocess
-from datetime import datetime
+from datetime import datetime, timezone
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Final
@@ -257,8 +257,12 @@ def parse_args() -> argparse.Namespace:
 if __name__ == "__main__":
     args = parse_args()
     tools = gather_tools()
-    # Sort newest first
-    tools.sort(key=lambda t: t.created or datetime.min, reverse=True)
+    # Sort newest first. get_git_date returns timezone-aware datetimes (git %aI),
+    # so the fallback for tools with no git creation date (e.g. generated redirect
+    # stubs that are gitignored and rebuilt fresh in CI) must also be aware —
+    # otherwise the sort raises "can't compare offset-naive and offset-aware".
+    epoch = datetime.min.replace(tzinfo=timezone.utc)
+    tools.sort(key=lambda t: t.created or epoch, reverse=True)
     html = build_html(tools)
     if not args.output_file.parent.exists():
         raise SystemExit(


### PR DESCRIPTION
## The failure

The **Deploy to GitHub Pages** workflow has failed on every push to `main` since PR #82. It crashes in `scripts/build_index.py:261`:

```
TypeError: can't compare offset-naive and offset-aware datetimes
  tools.sort(key=lambda t: t.created or datetime.min, reverse=True)
```

The live site is unaffected (Pages keeps serving the last good build), which is why it went unnoticed — see below.

## Root cause

`get_git_date` parses git's `%aI` output into **timezone-aware** datetimes, but the sort fallback was naive `datetime.min`. Python only rejects an aware-vs-naive comparison when it actually has to compare them — i.e. only when a scanned tool file has no git creation date (`t.created is None`), so the naive fallback lands in the sort key alongside aware dates.

That never happened until #82 (`Enforce redirect stubs stay gitignored and untracked`) gitignored and `git rm --cached`'d the generated stub `soundboard.html`. `scripts/build_redirects.py` now regenerates it fresh in CI *before* the index build, so it has no commit → `get_git_date` returns `None` → naive fallback enters the sort → crash. The bug itself has been latent in the code since `build_index.py` was created.

## Why it stayed hidden

- A failed Pages deploy keeps serving the previous successful build, so there was no visible outage.
- `pages.yml` runs only on `push` to `main`, never on PRs, so no pre-merge check ever went red.
- Locally the stub is present with full git history, so `t.created` is populated and the sort succeeds — it only reproduces in CI's clean-checkout + regenerate-artifact sequence.

## Fix

Make the fallback timezone-aware (`datetime.min` at UTC).

## Verification

Ran the CI sequence locally — `build_redirects.py` (which drops the untracked `soundboard.html` stub) followed by `build_index.py` — which now builds cleanly (8 tools) instead of raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)